### PR TITLE
JANDEX-4 fix to modify jar file on windows

### DIFF
--- a/src/main/java/org/jboss/jandex/JarIndexer.java
+++ b/src/main/java/org/jboss/jandex/JarIndexer.java
@@ -70,6 +70,9 @@ public class JarIndexer {
             Index index = indexer.complete();
             int bytes = writer.write(index);
 
+            out.close();
+            zo.close();
+            jar.close();
 
             if (modify) {
                 jarFile.delete();


### PR DESCRIPTION
It closes 3 streams that keep file handles open, and prevent delete and rename operation from succeed.
