### PR TITLE
Change array representation to match the representation used by the reflection API

### DIFF
--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -535,7 +535,9 @@ public final class Indexer {
                     while (descriptor.charAt(++end) != ';');
                 }
 
-                name = new DotName(null, descriptor.substring(start, end + 1), true);
+                //we replace the / characters with a .
+                //so it matches the name format returned by the reflection API
+                name = new DotName(null, descriptor.substring(start, end + 1).replace('/','.'), true);
                 kind = Type.Kind.ARRAY;
                 pos.i = end;
                 break;


### PR DESCRIPTION
This resolves a problem in the AS where annotations cannot be matched to methods that have an array as part of their signature 
