### PR TITLE
modify: renameTo() return unchecked, jar file lost

### DIFF
--- a/src/main/java/org/jboss/jandex/JarIndexer.java
+++ b/src/main/java/org/jboss/jandex/JarIndexer.java
@@ -92,7 +92,7 @@ public class JarIndexer {
                     FileOutputStream fos = new FileOutputStream(new File(jarFile.getAbsolutePath()));
                     try {
                         byte[] b = new byte[1024];
-                        for (int count=0; (count = fis.read(b, 0, 1024)) >= 1024;  ) {
+                        for (int count=0; (count = fis.read(b, 0, 1024)) >= 0;  ) {
                             fos.write(b, 0, count);
                         }
                     } finally {


### PR DESCRIPTION
see: #8 modify: renameTo() return unchecked, jar file lost 
