### PR TITLE
Support to invokedynamic bytecode

### DIFF
--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -73,7 +73,10 @@ public final class Indexer {
     private final static int CONSTANT_DOUBLE = 6;
     private final static int CONSTANT_NAMEANDTYPE = 12;
     private final static int CONSTANT_UTF8 = 1;
-
+    private final static int CONSTANT_INVOKEDYNAMIC = 18;
+    private final static int CONSTANT_METHODHANDLE = 15;
+    private final static int CONSTANT_METHODTYPE = 16;
+    
     // "RuntimeVisibleAnnotations"
     private final static byte[] RUNTIME_ANNOTATIONS = new byte[] {
         0x52, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x56, 0x69, 0x73, 0x69, 0x62,
@@ -581,6 +584,24 @@ public final class Indexer {
                     stream.readFully(buf, offset, 8);
                     offset += 8;
                     pos++; // 8 byte constant pool entries take two "virtual" slots for some reason
+                    break;
+                case CONSTANT_INVOKEDYNAMIC:
+                    buf = sizeToFit(buf, 5, offset, poolCount - pos);
+                    buf[offset++] = (byte) tag;
+                    stream.readFully(buf, offset, 4);
+                    offset += 4;
+                    break;
+                case CONSTANT_METHODHANDLE:
+                    buf = sizeToFit(buf, 4, offset, poolCount - pos);
+                    buf[offset++] = (byte) tag;
+                    stream.readFully(buf, offset, 3);
+                    offset += 3;
+                    break;
+                case CONSTANT_METHODTYPE:
+                    buf = sizeToFit(buf, 3, offset, poolCount - pos);
+                    buf[offset++] = (byte) tag;
+                    stream.readFully(buf, offset, 2);
+                    offset += 2;
                     break;
                 case CONSTANT_UTF8:
                     int len = stream.readUnsignedShort();


### PR DESCRIPTION
Introduced in jdk7 and used, by java language, in jdk8 with lambda expressions
It throws an exception with an invalid tag(18 invokedynamic)

Follow some logs:

Without lambda(invokedynamic):
Indexed br.com.janario.jdk8.Test$1 (0 annotations)
Indexed br.com.janario.jdk8.Test (0 annotations)
Wrote 7.idx in 0.0180 seconds (2 classes, 0 annotations, 0 instances, 99 bytes)

With lambda:
ERROR: Could not index Test.class: Unknown tag! pos=1 poolCount = 61
java.lang.IllegalStateException: Unknown tag! pos=1 poolCount = 61
    at org.jboss.jandex.Indexer.processConstantPool(Indexer.java:603)
    at org.jboss.jandex.Indexer.index(Indexer.java:637)
    at org.jboss.jandex.Main.scanFile(Main.java:146)
    at org.jboss.jandex.Main.scanFile(Main.java:135)
    at org.jboss.jandex.Main.indexDirectory(Main.java:101)
    at org.jboss.jandex.Main.execute(Main.java:69)
    at org.jboss.jandex.Main.main(Main.java:52)
Wrote 8.idx in 0.0140 seconds (0 classes, 0 annotations, 0 instances, 8 bytes)
