### PR TITLE
Fix reading invalid bytecode generated by Kotlin compiler

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -453,6 +453,13 @@ public final class Indexer {
                     }
                 }
                 int numParameters = data.readUnsignedByte();
+                if (target.asMethod().parameters().size() > 255) {
+                    // the Kotlin compiler happily generates methods with more than 255 parameters,
+                    // even if the JVM specification prohibits them, so if the method descriptor
+                    // indicates that so many parameters are present, let's use that count instead of
+                    // the one we just read (for extra safety, do NOT do this for compliant methods)
+                    numParameters = target.asMethod().parameters().size();
+                }
                 for (short p = 0; p < numParameters; p++) {
                     processAnnotations(data, new MethodParameterInfo((MethodInfo) target, p),
                             annotationAttribute == HAS_RUNTIME_PARAM_ANNOTATION);
@@ -670,6 +677,13 @@ public final class Indexer {
 
     private void processMethodParameters(DataInputStream data, MethodInfo target) throws IOException {
         int numParameters = data.readUnsignedByte();
+        if (target.parameters().size() > 255) {
+            // the Kotlin compiler happily generates methods with more than 255 parameters,
+            // even if the JVM specification prohibits them, so if the method descriptor
+            // indicates that so many parameters are present, let's use that count instead of
+            // the one we just read (for extra safety, do NOT do this for compliant methods)
+            numParameters = target.parameters().size();
+        }
         byte[][] parameterNames = numParameters > 0 ? new byte[numParameters][] : MethodInternal.EMPTY_PARAMETER_NAMES;
         int filledParameters = 0;
         for (int i = 0; i < numParameters; i++) {

--- a/core/src/test/java/org/jboss/jandex/test/TooManyMethodParametersTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TooManyMethodParametersTest.java
@@ -1,0 +1,85 @@
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.implementation.StubMethod;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface MyAnn {
+}
+
+public class TooManyMethodParametersTest {
+    private static final String TEST_CLASS = "org.jboss.jandex.test.TestClass";
+
+    // the Kotlin compiler happily generates methods with more than 255 parameters,
+    // even if the JVM specification prohibits them
+    //
+    // fortunately, ByteBuddy is happy to generate invalid methods too, so we can avoid
+    // bringing in Kotlin just to reproduce the issue
+
+    @Test
+    public void test() throws IOException {
+        DynamicType.Builder.MethodDefinition.ParameterDefinition<Object> builder = new ByteBuddy()
+                .with(new NamingStrategy.AbstractBase() {
+                    @Override
+                    protected String name(TypeDescription superClass) {
+                        return TEST_CLASS;
+                    }
+                })
+                .subclass(Object.class)
+                .defineMethod("hugeMethod", void.class)
+                .withParameter(String.class, "p0")
+                .annotateParameter(AnnotationDescription.Builder.ofType(MyAnn.class).build());
+        for (int i = 1; i < 300; i++) {
+            builder = builder.withParameter(String.class, "p" + i)
+                    .annotateParameter(AnnotationDescription.Builder.ofType(MyAnn.class).build());
+        }
+        byte[] syntheticClass = builder
+                .intercept(StubMethod.INSTANCE)
+                .make()
+                .getBytes();
+
+        Indexer indexer = new Indexer();
+        indexer.index(new ByteArrayInputStream(syntheticClass));
+        Index index = indexer.complete();
+
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(TEST_CLASS));
+        assertNotNull(clazz);
+        MethodInfo method = clazz.firstMethod("hugeMethod");
+        assertNotNull(method);
+
+        for (short i = 0; i < 300; i++) {
+            MethodParameterInfo param = MethodParameterInfo.create(method, i);
+            List<AnnotationInstance> paramAnnotations = new ArrayList<AnnotationInstance>();
+            for (AnnotationInstance annotation : method.annotations()) {
+                if (annotation.target().equals(param)) {
+                    paramAnnotations.add(annotation);
+                }
+            }
+            assertEquals(1, paramAnnotations.size());
+            assertEquals("MyAnn", paramAnnotations.get(0).name().withoutPackagePrefix());
+        }
+    }
+}


### PR DESCRIPTION
The JVM specification prohibits methods with more than 255 parameters
(and the number of parameters include the `this` implicit parameter
and even counts `long` and `double` parameters as two!).

Given this limitation, the class file format further only uses 1 byte
to store the number of method parameters on several places.

The Kotlin compiler, however, happily compiles code that includes
methods with more than 255 parameters, and the single-byte values
in the class file are just wrong. Hence, relying on those values
when parsing leads to complete mismatch.

This commit verifies the number of parameters as present in method
signature and when it's higher than 255, it discards the single-byte
value and uses the number of parameters. But all things considered,
this is really a workaround and Kotlin should be fixed.

Fixes #156