### PR TITLE
Add proper support for recursive type parameters

### DIFF
--- a/core/src/main/java/org/jboss/jandex/EquivalenceKey.java
+++ b/core/src/main/java/org/jboss/jandex/EquivalenceKey.java
@@ -47,6 +47,7 @@ import java.util.StringJoiner;
  * <li>{@code ParameterizedTypeEquivalenceKey}</li>
  * <li>{@code PrimitiveTypeEquivalenceKey}</li>
  * <li>{@code TypeVariableEquivalenceKey}</li>
+ * <li>{@code TypeVariableReferenceEquivalenceKey}</li>
  * <li>{@code UnresolvedTypeVariableEquivalenceKey}</li>
  * <li>{@code VoidTypeEquivalenceKey}</li>
  * <li>{@code WildcardTypeEquivalenceKey}</li>
@@ -192,6 +193,8 @@ public abstract class EquivalenceKey {
             case TYPE_VARIABLE:
                 return new TypeVariableEquivalenceKey(type.asTypeVariable().identifier(),
                         of(type.asTypeVariable().boundArray()));
+            case TYPE_VARIABLE_REFERENCE:
+                return new TypeVariableReferenceEquivalenceKey(type.asTypeVariableReference().identifier());
             case UNRESOLVED_TYPE_VARIABLE:
                 return new UnresolvedTypeVariableEquivalenceKey(type.asUnresolvedTypeVariable().identifier());
             case VOID:
@@ -612,6 +615,34 @@ public abstract class EquivalenceKey {
 
         String toStringWithWhere(Set<TypeVariableEquivalenceKey> typeVariables) {
             typeVariables.add(this);
+            return name;
+        }
+    }
+
+    public static final class TypeVariableReferenceEquivalenceKey extends TypeEquivalenceKey {
+        private final String name;
+
+        private TypeVariableReferenceEquivalenceKey(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof TypeVariableReferenceEquivalenceKey))
+                return false;
+            TypeVariableReferenceEquivalenceKey that = (TypeVariableReferenceEquivalenceKey) o;
+            return Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name);
+        }
+
+        @Override
+        public String toString() {
             return name;
         }
     }

--- a/core/src/main/java/org/jboss/jandex/JandexReflection.java
+++ b/core/src/main/java/org/jboss/jandex/JandexReflection.java
@@ -27,6 +27,10 @@ public class JandexReflection {
      * <li>for {@linkplain TypeVariable type variables}, returns the class object of the first bound
      * (e.g. {@code Number.class} for {@code T extends Number & Comparable<T>}), or {@code Object.class}
      * if the type variable has no bounds (e.g. just {@code T});</li>
+     * <li>for {@linkplain TypeVariableReference type variables references}, follows the reference to obtain the type
+     * variable and then returns the class object of the first bound (e.g. {@code Number.class} for
+     * {@code T extends Number & Comparable<T>}), or {@code Object.class} if the type variable has no bounds
+     * (e.g. just {@code T});</li>
      * <li>for {@linkplain UnresolvedTypeVariable unresolved type variables}, returns {@code Object.class}.</li>
      * </ul>
      *
@@ -77,6 +81,8 @@ public class JandexReflection {
                 return loadRawType(type.asWildcardType().extendsBound());
             case TYPE_VARIABLE:
                 return load(type.asTypeVariable().name());
+            case TYPE_VARIABLE_REFERENCE:
+                return load(type.asTypeVariableReference().name());
             case UNRESOLVED_TYPE_VARIABLE:
                 return Object.class; // can't do better here
             default:

--- a/core/src/main/java/org/jboss/jandex/ParameterizedType.java
+++ b/core/src/main/java/org/jboss/jandex/ParameterizedType.java
@@ -22,26 +22,23 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Represents a generic parameterized type. The <code>name()</code> corresponds to the raw type,
- * and the arguments list corresponds to a list of type arguments passed to the parameterized type.
- *
+ * Represents a parameterized type. The {@code name()} corresponds to the raw type, and the
+ * {@code arguments()} list corresponds to the type arguments passed to the generic type
+ * in order to instantiate this parameterized type.
  * <p>
- * Additionally, a parameterized type is used to represent an inner class whose enclosing class
- * is either parameterized or has type annotations. In this case, the <code>owner()</code> method
- * will specify the type for the enclosing class. It is also possible for such a type to be parameterized
- * itself.
- *
- * <p>
- * For example, the follow declaration would have a name of "java.util.Map", and two
- * <code>ClassType</code> arguments, the first being "java.lang.String", the second "java.lang.Integer":
+ * For example, the following declaration would have a name of {@code java.util.Map} and two
+ * {@code ClassType} arguments: {@code java.lang.String} and {@code java.lang.Integer}:
  *
  * <pre class="brush:java; gutter:false">
- *     java.util.Map&lt;String, Integer&gt;
+ *     Map&lt;String, Integer&gt;
  * </pre>
- *
  * <p>
- * Another example shows the case where a parameterized type is used to represent a non-parameterized
- * class (X), whose owner (Y) is itself parameterized:
+ * Additionally, a parameterized type is used to represent an inner type whose enclosing type
+ * is either parameterized or has type annotations. In this case, the {@code owner()} method
+ * returns the type of the enclosing class. Such inner type may itself be parameterized.
+ * <p>
+ * For example, the following declaration shows the case where a parameterized type is used
+ * to represent a non-parameterized class {@code X} whose owner {@code Y} is parameterized:
  *
  * <pre class="brush:java; gutter:false">
  *     Y&lt;String&gt;.X
@@ -80,7 +77,7 @@ public class ParameterizedType extends Type {
     }
 
     /**
-     * Returns the list of arguments passed to this Parameterized type.
+     * Returns the list of type arguments used to instantiate this parameterized type.
      *
      * @return the list of type arguments, or empty if none
      */
@@ -93,27 +90,22 @@ public class ParameterizedType extends Type {
     }
 
     /**
-     * Returns the owner (enclosing) type of this parameterized type if the owner is parameterized,
-     * or contains type annotations. The latter may be a <code>ClassType</code>. Otherwise null is
-     * returned.
-     *
+     * Returns the owner (enclosing) type of this parameterized type, if the owner is parameterized
+     * or has type annotations. In the latter case, the owner may be a {@code ClassType}. Returns
+     * {@code null} otherwise.
      * <p>
-     * Note that this means that inner classes whose enclosing types are not parameterized or
-     * annotated may return null when this method is called.
-     * </p>
-     *
+     * Note that parameterized inner classes whose enclosing types are not parameterized or type-annotated
+     * have no owner and hence this method returns {@code null} in such case.
      * <p>
-     * The example below shows the case where a parameterized type is used to represent a non-parameterized
-     * class (X).
+     * This example shows the case where a parameterized type is used to represent a non-parameterized
+     * class {@code X}:
      *
      * <pre class="brush:java; gutter:false;">
      *     Y&lt;String&gt;.X
      * </pre>
      *
-     * <p>
-     * This example will return a parameterized type for "Y" when X's <code>owner()</code> method
+     * This example will return a parameterized type for {@code Y} when {@code X}'s {@code owner()} method
      * is called.
-     * </p>
      *
      * @return the owner type if the owner is parameterized or annotated, otherwise null
      */

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -55,8 +55,7 @@ public abstract class Type {
         ARRAY,
 
         /**
-         * A Java primitive (boolean, byte, short, char, int, long, float,
-         * double)
+         * A Java primitive (boolean, byte, short, char, int, long, float, double)
          */
         PRIMITIVE,
 
@@ -73,14 +72,18 @@ public abstract class Type {
          */
         UNRESOLVED_TYPE_VARIABLE,
 
-        /** A generic wildcard type. */
+        /** A generic wildcard type */
         WILDCARD_TYPE,
 
         /** A generic parameterized type */
-        PARAMETERIZED_TYPE;
+        PARAMETERIZED_TYPE,
+
+        /** A reference to a resolved type variable occuring in the bound of a recursive type parameter */
+        TYPE_VARIABLE_REFERENCE,
+
+        ;
 
         public static Kind fromOrdinal(int ordinal) {
-
             switch (ordinal) {
                 case 0:
                     return CLASS;
@@ -99,6 +102,8 @@ public abstract class Type {
                     return WILDCARD_TYPE;
                 case 7:
                     return PARAMETERIZED_TYPE;
+                case 8:
+                    return TYPE_VARIABLE_REFERENCE;
             }
         }
     }
@@ -205,7 +210,7 @@ public abstract class Type {
     public abstract Kind kind();
 
     /**
-     * Casts this type to a {@link org.jboss.jandex.ClassType} and returns it if the kind is {@link Kind#CLASS}
+     * Casts this type to a {@link org.jboss.jandex.ClassType} and returns it if the kind is {@link Kind#CLASS}.
      * Throws an exception otherwise.
      *
      * @return a <code>ClassType</code>
@@ -218,10 +223,9 @@ public abstract class Type {
 
     /**
      * Casts this type to a {@link org.jboss.jandex.ParameterizedType} and returns it if the kind is
-     * {@link Kind#PARAMETERIZED_TYPE}
-     * Throws an exception otherwise.
+     * {@link Kind#PARAMETERIZED_TYPE}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return a {@code ParameterizedType}
      * @throws java.lang.IllegalArgumentException if not a parameterized type
      * @since 2.0
      */
@@ -230,11 +234,10 @@ public abstract class Type {
     }
 
     /**
-     * Casts this type to a {@link org.jboss.jandex.ParameterizedType} and returns it if the kind is
-     * {@link Kind#TYPE_VARIABLE}
-     * Throws an exception otherwise.
+     * Casts this type to a {@link org.jboss.jandex.TypeVariable} and returns it if the kind is
+     * {@link Kind#TYPE_VARIABLE}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return a {@code TypeVariable}
      * @throws java.lang.IllegalArgumentException if not a type variable
      * @since 2.0
      */
@@ -243,11 +246,22 @@ public abstract class Type {
     }
 
     /**
-     * Casts this type to an {@link org.jboss.jandex.ArrayType} and returns it if the kind is
-     * {@link Kind#ARRAY}
-     * Throws an exception otherwise.
+     * Casts this type to a {@link org.jboss.jandex.TypeVariableReference} and returns it if the kind is
+     * {@link Kind#TYPE_VARIABLE_REFERENCE}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return a {@code TypeVariableReference}
+     * @throws java.lang.IllegalArgumentException if not a type variable
+     * @since 2.0
+     */
+    public TypeVariableReference asTypeVariableReference() {
+        throw new IllegalArgumentException("Not a type variable reference!");
+    }
+
+    /**
+     * Casts this type to an {@link org.jboss.jandex.ArrayType} and returns it if the kind is
+     * {@link Kind#ARRAY}. Throws an exception otherwise.
+     *
+     * @return an {@code ArrayType}
      * @throws java.lang.IllegalArgumentException if not an array type
      * @since 2.0
      */
@@ -257,10 +271,9 @@ public abstract class Type {
 
     /**
      * Casts this type to a {@link org.jboss.jandex.WildcardType} and returns it if the kind is
-     * {@link Kind#WILDCARD_TYPE}
-     * Throws an exception otherwise.
+     * {@link Kind#WILDCARD_TYPE}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return a {@code WildcardType}
      * @throws java.lang.IllegalArgumentException if not a wildcard type
      * @since 2.0
      */
@@ -270,10 +283,9 @@ public abstract class Type {
 
     /**
      * Casts this type to an {@link org.jboss.jandex.UnresolvedTypeVariable} and returns it if the kind is
-     * {@link Kind#UNRESOLVED_TYPE_VARIABLE}
-     * Throws an exception otherwise.
+     * {@link Kind#UNRESOLVED_TYPE_VARIABLE}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return an {@code UnresolvedTypeVariable}
      * @throws java.lang.IllegalArgumentException if not an unresolved type
      * @since 2.0
      */
@@ -283,10 +295,9 @@ public abstract class Type {
 
     /**
      * Casts this type to a {@link org.jboss.jandex.PrimitiveType} and returns it if the kind is
-     * {@link Kind#PRIMITIVE}
-     * Throws an exception otherwise.
+     * {@link Kind#PRIMITIVE}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return a {@code PrimitiveType}
      * @throws java.lang.IllegalArgumentException if not a primitive type
      * @since 2.0
      */
@@ -296,10 +307,9 @@ public abstract class Type {
 
     /**
      * Casts this type to a {@link org.jboss.jandex.VoidType} and returns it if the kind is
-     * {@link Kind#VOID}
-     * Throws an exception otherwise.
+     * {@link Kind#VOID}. Throws an exception otherwise.
      *
-     * @return a <code>ClassType</code>
+     * @return a {@code VoidType}
      * @throws java.lang.IllegalArgumentException if not a void type
      * @since 2.0
      */

--- a/core/src/main/java/org/jboss/jandex/TypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariable.java
@@ -63,10 +63,20 @@ public final class TypeVariable extends Type {
     }
 
     TypeVariable(String name, Type[] bounds, AnnotationInstance[] annotations, boolean implicitObjectBound) {
-        super(bounds.length > 0 ? bounds[0].name() : DotName.OBJECT_NAME, annotations);
+        // can't get the name here, because the bound may be a not-yet-patched type variable reference
+        // (hence we also need to override the name() method, see below)
+        super(DotName.OBJECT_NAME, annotations);
         this.name = name;
         this.bounds = bounds;
         this.hash = implicitObjectBound ? Integer.MIN_VALUE : 0;
+    }
+
+    @Override
+    public DotName name() {
+        if (bounds.length > 0) {
+            return bounds[0].name();
+        }
+        return DotName.OBJECT_NAME;
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/TypeVariableReference.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariableReference.java
@@ -1,0 +1,130 @@
+package org.jboss.jandex;
+
+/**
+ * Represents a reference to a type variable in the bound of a recursive type parameter.
+ * For example, if a class or method declares a type parameter {@code T extends Comparable<T>},
+ * then the second occurence of {@code T} is represented as a type variable reference and not
+ * as a type variable, because it occurs in its own definition. A type variable which is fully
+ * defined before its occurence in a recursive type parameter is still represented as a type
+ * variable. For example, the recursive type parameter in the following class includes
+ * one type variable reference:
+ *
+ * <pre class="brush:java; gutter: false;">
+ * abstract class Builder&lt;T, THIS extends Builder&lt;T, THIS>> {
+ *     abstract T build();
+ *
+ *     final THIS self() {
+ *         return (THIS) this;
+ *     }
+ * }
+ * </pre>
+ *
+ * The identifier of the reference is {@code THIS}. The occurence of type variable {@code T}
+ * in the recursive type parameter is <em>not</em> represented as a reference, because it does not
+ * occur in its own definition. It is fully defined before.
+ * <p>
+ * The same holds for mutually recursive type parameters. If a type variable is fully defined
+ * before the type parameter in whose bound it occurs, it is represented as a type variable.
+ * It is represented as a type variable reference if it is defined after the type parameter in whose
+ * bound it occurs.
+ * <p>
+ * The type variable reference may be {@linkplain #follow() followed} to obtain the original
+ * type variable.
+ * <p>
+ * Note that a type variable and a reference to that type variable may have different
+ * type annotations. Type annotations on the reference may be looked up from the reference,
+ * but when the reference is followed, the result is the original type variable with its
+ * own type annotations.
+ */
+public final class TypeVariableReference extends Type {
+    private final String name;
+    private TypeVariable target;
+
+    TypeVariableReference(String name) {
+        this(name, null, null);
+    }
+
+    TypeVariableReference(String name, TypeVariable target, AnnotationInstance[] annotations) {
+        super(DotName.OBJECT_NAME, annotations);
+        this.name = name;
+        this.target = target;
+    }
+
+    @Override
+    public DotName name() {
+        if (target == null) {
+            throw new IllegalStateException("Type variable reference " + name + " was not patched correctly");
+        }
+        return target.name();
+    }
+
+    /**
+     * Returns the identifier of this type variable reference as it appears in Java source code.
+     * <p>
+     * For example, the following class has a recursive type parameter {@code E} with one reference:
+     *
+     * <pre class="brush:java; gutter: false;">
+     * abstract class MyEnum&lt;E extends MyEnum&lt;E>> {
+     * }
+     * </pre>
+     *
+     * The identifier of the reference is {@code E}.
+     *
+     * @return the identifier of this type variable reference
+     */
+    public String identifier() {
+        return name;
+    }
+
+    /**
+     * Returns the type variable refered to by this reference.
+     */
+    public TypeVariable follow() {
+        if (target == null) {
+            throw new IllegalStateException("Type variable reference " + name + " was not patched correctly");
+        }
+        return target;
+    }
+
+    @Override
+    public Kind kind() {
+        return Kind.TYPE_VARIABLE_REFERENCE;
+    }
+
+    @Override
+    public TypeVariableReference asTypeVariableReference() {
+        return this;
+    }
+
+    @Override
+    String toString(boolean simple) {
+        StringBuilder builder = new StringBuilder();
+        appendAnnotations(builder);
+        builder.append(name);
+        return builder.toString();
+    }
+
+    @Override
+    Type copyType(AnnotationInstance[] newAnnotations) {
+        return new TypeVariableReference(name, target, newAnnotations);
+    }
+
+    // unlike all other subclasses of `Type`, this class is mutable,
+    // so identity equality and hash code are the only option
+    @Override
+    public boolean equals(Object o) {
+        return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
+    void setTarget(TypeVariable target) {
+        if (target == null) {
+            throw new IllegalArgumentException("Type variable reference target must not be null");
+        }
+        this.target = target;
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/UnresolvedTypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/UnresolvedTypeVariable.java
@@ -26,7 +26,6 @@ package org.jboss.jandex;
  */
 public final class UnresolvedTypeVariable extends Type {
     private final String name;
-    private int hash;
 
     UnresolvedTypeVariable(String name) {
         this(name, null);
@@ -38,10 +37,9 @@ public final class UnresolvedTypeVariable extends Type {
     }
 
     /**
-     * The identifier of this unresolved type variable as it appears in Java source code.
-     *
+     * Returns the identifier of this unresolved type variable as it appears in Java source code.
      * <p>
-     * The following class has a type parameter, with an identifier of "T":
+     * For example, the following class has a type parameter with an identifier of {@code T}:
      *
      * <pre class="brush:java; gutter: false;">
      * class Foo&lt;T extends Number&gt; {

--- a/core/src/main/java/org/jboss/jandex/WildcardType.java
+++ b/core/src/main/java/org/jboss/jandex/WildcardType.java
@@ -50,10 +50,20 @@ public class WildcardType extends Type {
     }
 
     WildcardType(Type bound, boolean isExtends, AnnotationInstance[] annotations) {
-        super(isExtends && bound != null ? bound.name() : DotName.OBJECT_NAME, annotations);
+        // can't get the name here, because the bound may be a not-yet-patched type variable reference
+        // (hence we also need to override the name() method, see below)
+        super(DotName.OBJECT_NAME, annotations);
         this.bound = isExtends && bound == null ? OBJECT : bound;
         this.isExtends = isExtends;
 
+    }
+
+    @Override
+    public DotName name() {
+        if (isExtends && bound != null) {
+            return bound.name();
+        }
+        return DotName.OBJECT_NAME;
     }
 
     /**

--- a/core/src/test/java/org/jboss/jandex/test/MutuallyRecursiveTypeParametersTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/MutuallyRecursiveTypeParametersTest.java
@@ -1,0 +1,234 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.TypeVariableReference;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class MutuallyRecursiveTypeParametersTest {
+    static class IndirectRecursion<A extends List<B>, B extends List<A>> {
+        A a;
+        B b;
+    }
+
+    static class Graph<G extends Graph<G, E, V>, E extends Edge<G, E, V>, V extends Vertex<G, E, V>> {
+        Set<E> edges;
+        Set<V> vertices;
+
+        Set<E> getEdges() {
+            return edges;
+        }
+
+        Set<V> getVertices() {
+            return vertices;
+        }
+    }
+
+    static class Edge<G extends Graph<G, E, V>, E extends Edge<G, E, V>, V extends Vertex<G, E, V>> {
+        G graph;
+        V source;
+        V target;
+
+        G getGraph() {
+            return graph;
+        }
+
+        V getSource() {
+            return source;
+        }
+
+        V getTarget() {
+            return target;
+        }
+    }
+
+    static class Vertex<G extends Graph<G, E, V>, E extends Edge<G, E, V>, V extends Vertex<G, E, V>> {
+        G graph;
+        Set<E> incoming;
+        Set<E> outgoing;
+
+        G getGraph() {
+            return graph;
+        }
+
+        Set<E> getIncoming() {
+            return incoming;
+        }
+
+        Set<E> getOutgoing() {
+            return outgoing;
+        }
+    }
+
+    @Test
+    public void indirectRecursion() throws IOException {
+        Index index = Index.of(IndirectRecursion.class);
+        indirectRecursion(index);
+        indirectRecursion(IndexingUtil.roundtrip(index));
+    }
+
+    private void indirectRecursion(Index index) {
+        ClassInfo indirectlyRecursive = index.getClassByName(IndirectRecursion.class);
+        assertEquals(2, indirectlyRecursive.typeParameters().size());
+        assertA(indirectlyRecursive.typeParameters().get(0));
+        assertB(indirectlyRecursive.typeParameters().get(1));
+        assertA(indirectlyRecursive.field("a").type());
+        assertB(indirectlyRecursive.field("b").type());
+    }
+
+    private void assertA(Type a) {
+        assertTrue(a.kind() == Type.Kind.TYPE_VARIABLE || a.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (a.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable aVar = a.asTypeVariable();
+            assertEquals("A", aVar.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), aVar.name());
+            assertEquals(1, aVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, aVar.bounds().get(0).kind());
+            ParameterizedType aBound = aVar.bounds().get(0).asParameterizedType();
+            assertEquals(1, aBound.arguments().size());
+            assertB(aBound.arguments().get(0));
+            //assertSame(a, aBound.arguments().get(0).asTypeVariableReference().follow());
+        } else {
+            TypeVariableReference aRef = a.asTypeVariableReference();
+            assertEquals("A", aRef.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), aRef.name());
+        }
+    }
+
+    private void assertB(Type b) {
+        assertTrue(b.kind() == Type.Kind.TYPE_VARIABLE || b.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (b.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable bVar = b.asTypeVariable();
+            assertEquals("B", bVar.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), bVar.name());
+            assertEquals(1, bVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, bVar.bounds().get(0).kind());
+            ParameterizedType bBound = bVar.bounds().get(0).asParameterizedType();
+            assertEquals(1, bBound.arguments().size());
+            assertA(bBound.arguments().get(0));
+            //assertSame(b, bBound.arguments().get(0).asTypeVariableReference().follow());
+        } else {
+            TypeVariableReference bRef = b.asTypeVariableReference();
+            assertEquals("B", bRef.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), bRef.name());
+        }
+    }
+
+    @Test
+    public void typeFamily() throws IOException {
+        Index index = Index.of(Graph.class, Edge.class, Vertex.class);
+        typeFamily(index);
+        typeFamily(IndexingUtil.roundtrip(index));
+    }
+
+    private void typeFamily(Index index) {
+        ClassInfo graph = index.getClassByName(Graph.class);
+        assertClassInTypeFamily(graph);
+        assertE(graph.field("edges").type().asParameterizedType().arguments().get(0));
+        assertV(graph.field("vertices").type().asParameterizedType().arguments().get(0));
+        assertE(graph.method("getEdges").returnType().asParameterizedType().arguments().get(0));
+        assertV(graph.method("getVertices").returnType().asParameterizedType().arguments().get(0));
+
+        ClassInfo edge = index.getClassByName(Edge.class);
+        assertClassInTypeFamily(edge);
+        assertG(edge.field("graph").type());
+        assertV(edge.field("source").type());
+        assertV(edge.field("target").type());
+        assertG(edge.method("getGraph").returnType());
+        assertV(edge.method("getSource").returnType());
+        assertV(edge.method("getTarget").returnType());
+
+        ClassInfo vertex = index.getClassByName(Vertex.class);
+        assertClassInTypeFamily(vertex);
+        assertG(vertex.field("graph").type());
+        assertE(vertex.field("incoming").type().asParameterizedType().arguments().get(0));
+        assertE(vertex.field("outgoing").type().asParameterizedType().arguments().get(0));
+        assertG(vertex.method("getGraph").returnType());
+        assertE(vertex.method("getIncoming").returnType().asParameterizedType().arguments().get(0));
+        assertE(vertex.method("getOutgoing").returnType().asParameterizedType().arguments().get(0));
+    }
+
+    private void assertClassInTypeFamily(ClassInfo clazz) {
+        List<TypeVariable> typeParameters = clazz.typeParameters();
+        assertEquals(3, typeParameters.size());
+        assertG(typeParameters.get(0));
+        assertE(typeParameters.get(1));
+        assertV(typeParameters.get(2));
+    }
+
+    private void assertG(Type g) {
+        assertTrue(g.kind() == Type.Kind.TYPE_VARIABLE || g.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (g.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable gVar = g.asTypeVariable();
+            assertEquals("G", gVar.identifier());
+            assertEquals(DotName.createSimple(Graph.class.getName()), gVar.name());
+            assertEquals(1, gVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, gVar.bounds().get(0).kind());
+            ParameterizedType gBound = gVar.bounds().get(0).asParameterizedType();
+            assertEquals(3, gBound.arguments().size());
+            assertG(gBound.arguments().get(0));
+            assertSame(g, gBound.arguments().get(0).asTypeVariableReference().follow());
+            assertE(gBound.arguments().get(1));
+            assertV(gBound.arguments().get(2));
+        } else {
+            TypeVariableReference gRef = g.asTypeVariableReference();
+            assertEquals("G", gRef.identifier());
+            assertEquals(DotName.createSimple(Graph.class.getName()), gRef.name());
+        }
+    }
+
+    private void assertE(Type e) {
+        assertTrue(e.kind() == Type.Kind.TYPE_VARIABLE || e.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (e.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable eVar = e.asTypeVariable();
+            assertEquals("E", eVar.identifier());
+            assertEquals(DotName.createSimple(Edge.class.getName()), eVar.name());
+            assertEquals(1, eVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, eVar.bounds().get(0).kind());
+            ParameterizedType eBound = eVar.bounds().get(0).asParameterizedType();
+            assertEquals(3, eBound.arguments().size());
+            assertG(eBound.arguments().get(0));
+            assertE(eBound.arguments().get(1));
+            assertSame(e, eBound.arguments().get(1).asTypeVariableReference().follow());
+            assertV(eBound.arguments().get(2));
+        } else {
+            TypeVariableReference eRef = e.asTypeVariableReference();
+            assertEquals("E", eRef.identifier());
+            assertEquals(DotName.createSimple(Edge.class.getName()), eRef.name());
+        }
+    }
+
+    private void assertV(Type v) {
+        assertTrue(v.kind() == Type.Kind.TYPE_VARIABLE || v.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (v.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable vVar = v.asTypeVariable();
+            assertEquals("V", vVar.identifier());
+            assertEquals(DotName.createSimple(Vertex.class.getName()), vVar.name());
+            assertEquals(1, vVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, vVar.bounds().get(0).kind());
+            ParameterizedType vBound = vVar.bounds().get(0).asParameterizedType();
+            assertEquals(3, vBound.arguments().size());
+            assertG(vBound.arguments().get(0));
+            assertE(vBound.arguments().get(1));
+            assertV(vBound.arguments().get(2));
+            assertSame(v, vBound.arguments().get(2).asTypeVariableReference().follow());
+        } else {
+            TypeVariableReference vRef = v.asTypeVariableReference();
+            assertEquals("V", vRef.identifier());
+            assertEquals(DotName.createSimple(Vertex.class.getName()), vRef.name());
+        }
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/MutuallyRecursiveTypeParametersWithAnnotationsTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/MutuallyRecursiveTypeParametersWithAnnotationsTest.java
@@ -1,0 +1,270 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.TypeVariableReference;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class MutuallyRecursiveTypeParametersWithAnnotationsTest {
+    static class IndirectRecursion<@MyAnnotation("class:var:a") A extends List<@MyAnnotation("a:ref:b") B>, @MyAnnotation("class:var:b") B extends List<@MyAnnotation("b:var:a") A>> {
+        @MyAnnotation("field a:var:a")
+        A a;
+
+        @MyAnnotation("field b:var:b")
+        B b;
+    }
+
+    static class Graph<@MyAnnotation("class Graph:var:g") G extends Graph<@MyAnnotation("g:ref:g") G, @MyAnnotation("g:ref:e") E, @MyAnnotation("g:ref:v") V>, @MyAnnotation("class Graph:var:e") E extends Edge<@MyAnnotation("e:var:g") G, @MyAnnotation("e:ref:e") E, @MyAnnotation("e:ref:v") V>, @MyAnnotation("class Graph:var:v") V extends Vertex<@MyAnnotation("v:var:g") G, @MyAnnotation("v:var:e") E, @MyAnnotation("v:ref:v") V>> {
+        Set<@MyAnnotation("field Graph.edges:var:e") E> edges;
+
+        Set<@MyAnnotation("field Graph.vertices:var:v") V> vertices;
+
+        Set<@MyAnnotation("method Graph.getEdges:var:e") E> getEdges() {
+            return edges;
+        }
+
+        Set<@MyAnnotation("method Graph.getVertices:var:v") V> getVertices() {
+            return vertices;
+        }
+    }
+
+    static class Edge<@MyAnnotation("class Edge:var:g") G extends Graph<@MyAnnotation("g:ref:g") G, @MyAnnotation("g:ref:e") E, @MyAnnotation("g:ref:v") V>, @MyAnnotation("class Edge:var:e") E extends Edge<@MyAnnotation("e:var:g") G, @MyAnnotation("e:ref:e") E, @MyAnnotation("e:ref:v") V>, @MyAnnotation("class Edge:var:v") V extends Vertex<@MyAnnotation("v:var:g") G, @MyAnnotation("v:var:e") E, @MyAnnotation("v:ref:v") V>> {
+        @MyAnnotation("field Edge.graph:var:g")
+        G graph;
+
+        @MyAnnotation("field Edge.source:var:v")
+        V source;
+
+        @MyAnnotation("field Edge.target:var:v")
+        V target;
+
+        @MyAnnotation("method Edge.getGraph:var:g")
+        G getGraph() {
+            return graph;
+        }
+
+        @MyAnnotation("method Edge.getSource:var:v")
+        V getSource() {
+            return source;
+        }
+
+        @MyAnnotation("method Edge.getTarget:var:v")
+        V getTarget() {
+            return target;
+        }
+    }
+
+    static class Vertex<@MyAnnotation("class Vertex:var:g") G extends Graph<@MyAnnotation("g:ref:g") G, @MyAnnotation("g:ref:e") E, @MyAnnotation("g:ref:v") V>, @MyAnnotation("class Vertex:var:e") E extends Edge<@MyAnnotation("e:var:g") G, @MyAnnotation("e:ref:e") E, @MyAnnotation("e:ref:v") V>, @MyAnnotation("class Vertex:var:v") V extends Vertex<@MyAnnotation("v:var:g") G, @MyAnnotation("v:var:e") E, @MyAnnotation("v:ref:v") V>> {
+        @MyAnnotation("field Vertex.graph:var:g")
+        G graph;
+
+        Set<@MyAnnotation("field Vertex.incoming:var:e") E> incoming;
+
+        Set<@MyAnnotation("field Vertex.outgoing:var:e") E> outgoing;
+
+        @MyAnnotation("method Vertex.getGraph:var:g")
+        G getGraph() {
+            return graph;
+        }
+
+        Set<@MyAnnotation("method Vertex.getIncoming:var:e") E> getIncoming() {
+            return incoming;
+        }
+
+        Set<@MyAnnotation("method Vertex.getOutgoing:var:e") E> getOutgoing() {
+            return outgoing;
+        }
+    }
+
+    @Test
+    public void indirectRecursion() throws IOException {
+        Index index = Index.of(IndirectRecursion.class);
+        indirectRecursion(index);
+        indirectRecursion(IndexingUtil.roundtrip(index));
+    }
+
+    private void indirectRecursion(Index index) {
+        ClassInfo indirectlyRecursive = index.getClassByName(IndirectRecursion.class);
+        assertEquals(2, indirectlyRecursive.typeParameters().size());
+        assertA(indirectlyRecursive.typeParameters().get(0), "class");
+        assertB(indirectlyRecursive.typeParameters().get(1), "class");
+        assertA(indirectlyRecursive.field("a").type(), "field a");
+        assertB(indirectlyRecursive.field("b").type(), "field b");
+    }
+
+    private void assertA(Type a, String origin) {
+        assertTrue(a.kind() == Type.Kind.TYPE_VARIABLE || a.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (a.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable aVar = a.asTypeVariable();
+            assertEquals("A", aVar.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), aVar.name());
+            assertTrue(aVar.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":var:a", aVar.annotation(MyAnnotation.DOT_NAME).value().asString());
+            assertEquals(1, aVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, aVar.bounds().get(0).kind());
+            ParameterizedType aBound = aVar.bounds().get(0).asParameterizedType();
+            assertEquals(1, aBound.arguments().size());
+            assertB(aBound.arguments().get(0), "a");
+        } else {
+            TypeVariableReference aRef = a.asTypeVariableReference();
+            assertEquals("A", aRef.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), aRef.name());
+            assertTrue(aRef.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":ref:a", aRef.annotation(MyAnnotation.DOT_NAME).value().asString());
+        }
+    }
+
+    private void assertB(Type b, String origin) {
+        assertTrue(b.kind() == Type.Kind.TYPE_VARIABLE || b.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (b.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable bVar = b.asTypeVariable();
+            assertEquals("B", bVar.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), bVar.name());
+            assertTrue(bVar.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":var:b", bVar.annotation(MyAnnotation.DOT_NAME).value().asString());
+            assertEquals(1, bVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, bVar.bounds().get(0).kind());
+            ParameterizedType bBound = bVar.bounds().get(0).asParameterizedType();
+            assertEquals(1, bBound.arguments().size());
+            assertA(bBound.arguments().get(0), "b");
+        } else {
+            TypeVariableReference bRef = b.asTypeVariableReference();
+            assertEquals("B", bRef.identifier());
+            assertEquals(DotName.createSimple(List.class.getName()), bRef.name());
+            assertTrue(bRef.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":ref:b", bRef.annotation(MyAnnotation.DOT_NAME).value().asString());
+        }
+    }
+
+    @Test
+    public void typeFamily() throws IOException {
+        Index index = Index.of(Graph.class, Edge.class, Vertex.class);
+        typeFamily(index);
+        typeFamily(IndexingUtil.roundtrip(index));
+    }
+
+    private void typeFamily(Index index) {
+        ClassInfo graph = index.getClassByName(Graph.class);
+        assertClassInTypeFamily(graph, "class Graph");
+        assertE(graph.field("edges").type().asParameterizedType().arguments().get(0), "field Graph.edges");
+        assertV(graph.field("vertices").type().asParameterizedType().arguments().get(0), "field Graph.vertices");
+        assertE(graph.method("getEdges").returnType().asParameterizedType().arguments().get(0), "method Graph.getEdges");
+        assertV(graph.method("getVertices").returnType().asParameterizedType().arguments().get(0), "method Graph.getVertices");
+
+        ClassInfo edge = index.getClassByName(Edge.class);
+        assertClassInTypeFamily(edge, "class Edge");
+        assertG(edge.field("graph").type(), "field Edge.graph");
+        assertV(edge.field("source").type(), "field Edge.source");
+        assertV(edge.field("target").type(), "field Edge.target");
+        assertG(edge.method("getGraph").returnType(), "method Edge.getGraph");
+        assertV(edge.method("getSource").returnType(), "method Edge.getSource");
+        assertV(edge.method("getTarget").returnType(), "method Edge.getTarget");
+
+        ClassInfo vertex = index.getClassByName(Vertex.class);
+        assertClassInTypeFamily(vertex, "class Vertex");
+        assertG(vertex.field("graph").type(), "field Vertex.graph");
+        assertE(vertex.field("incoming").type().asParameterizedType().arguments().get(0), "field Vertex.incoming");
+        assertE(vertex.field("outgoing").type().asParameterizedType().arguments().get(0), "field Vertex.outgoing");
+        assertG(vertex.method("getGraph").returnType(), "method Vertex.getGraph");
+        assertE(vertex.method("getIncoming").returnType().asParameterizedType().arguments().get(0),
+                "method Vertex.getIncoming");
+        assertE(vertex.method("getOutgoing").returnType().asParameterizedType().arguments().get(0),
+                "method Vertex.getOutgoing");
+    }
+
+    private void assertClassInTypeFamily(ClassInfo clazz, String origin) {
+        List<TypeVariable> typeParameters = clazz.typeParameters();
+        assertEquals(3, typeParameters.size());
+        assertG(typeParameters.get(0), origin);
+        assertE(typeParameters.get(1), origin);
+        assertV(typeParameters.get(2), origin);
+    }
+
+    private void assertG(Type g, String origin) {
+        assertTrue(g.kind() == Type.Kind.TYPE_VARIABLE || g.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (g.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable gVar = g.asTypeVariable();
+            assertEquals("G", gVar.identifier());
+            assertEquals(DotName.createSimple(Graph.class.getName()), gVar.name());
+            assertTrue(gVar.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":var:g", gVar.annotation(MyAnnotation.DOT_NAME).value().asString());
+            assertEquals(1, gVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, gVar.bounds().get(0).kind());
+            ParameterizedType gBound = gVar.bounds().get(0).asParameterizedType();
+            assertEquals(3, gBound.arguments().size());
+            assertG(gBound.arguments().get(0), "g");
+            assertSame(g, gBound.arguments().get(0).asTypeVariableReference().follow());
+            assertE(gBound.arguments().get(1), "g");
+            assertV(gBound.arguments().get(2), "g");
+        } else {
+            TypeVariableReference gRef = g.asTypeVariableReference();
+            assertEquals("G", gRef.identifier());
+            assertEquals(DotName.createSimple(Graph.class.getName()), gRef.name());
+            assertTrue(gRef.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":ref:g", gRef.annotation(MyAnnotation.DOT_NAME).value().asString());
+        }
+    }
+
+    private void assertE(Type e, String origin) {
+        assertTrue(e.kind() == Type.Kind.TYPE_VARIABLE || e.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (e.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable eVar = e.asTypeVariable();
+            assertEquals("E", eVar.identifier());
+            assertEquals(DotName.createSimple(Edge.class.getName()), eVar.name());
+            assertTrue(eVar.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":var:e", eVar.annotation(MyAnnotation.DOT_NAME).value().asString());
+            assertEquals(1, eVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, eVar.bounds().get(0).kind());
+            ParameterizedType eBound = eVar.bounds().get(0).asParameterizedType();
+            assertEquals(3, eBound.arguments().size());
+            assertG(eBound.arguments().get(0), "e");
+            assertE(eBound.arguments().get(1), "e");
+            assertSame(e, eBound.arguments().get(1).asTypeVariableReference().follow());
+            assertV(eBound.arguments().get(2), "e");
+        } else {
+            TypeVariableReference eRef = e.asTypeVariableReference();
+            assertEquals("E", eRef.identifier());
+            assertEquals(DotName.createSimple(Edge.class.getName()), eRef.name());
+            assertTrue(eRef.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":ref:e", eRef.annotation(MyAnnotation.DOT_NAME).value().asString());
+        }
+    }
+
+    private void assertV(Type v, String origin) {
+        assertTrue(v.kind() == Type.Kind.TYPE_VARIABLE || v.kind() == Type.Kind.TYPE_VARIABLE_REFERENCE);
+        if (v.kind() == Type.Kind.TYPE_VARIABLE) {
+            TypeVariable vVar = v.asTypeVariable();
+            assertEquals("V", vVar.identifier());
+            assertEquals(DotName.createSimple(Vertex.class.getName()), vVar.name());
+            assertEquals(origin + ":var:v", vVar.annotation(MyAnnotation.DOT_NAME).value().asString());
+            assertEquals(1, vVar.bounds().size());
+            assertEquals(1, vVar.bounds().size());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, vVar.bounds().get(0).kind());
+            ParameterizedType vBound = vVar.bounds().get(0).asParameterizedType();
+            assertEquals(3, vBound.arguments().size());
+            assertG(vBound.arguments().get(0), "v");
+            assertE(vBound.arguments().get(1), "v");
+            assertV(vBound.arguments().get(2), "v");
+            assertSame(v, vBound.arguments().get(2).asTypeVariableReference().follow());
+        } else {
+            TypeVariableReference vRef = v.asTypeVariableReference();
+            assertEquals("V", vRef.identifier());
+            assertEquals(DotName.createSimple(Vertex.class.getName()), vRef.name());
+            assertTrue(vRef.hasAnnotation(MyAnnotation.DOT_NAME));
+            assertEquals(origin + ":ref:v", vRef.annotation(MyAnnotation.DOT_NAME).value().asString());
+        }
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/ParameterizedTypeOwnerTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/ParameterizedTypeOwnerTest.java
@@ -1,0 +1,359 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class ParameterizedTypeOwnerTest {
+    class A {
+        class B {
+        }
+    }
+
+    class C<T> {
+        class D {
+        }
+    }
+
+    class E<T extends E<T>> {
+        class F {
+        }
+
+        class G extends E.F {
+        }
+
+        class H extends @MyAnnotation("e") E.F {
+        }
+
+        class I extends E.@MyAnnotation("f") F {
+        }
+
+        class J extends E<T>.F {
+        }
+
+        class K extends @MyAnnotation("e") E<T>.F {
+        }
+
+        class L extends E<@MyAnnotation("e.t") T>.F {
+        }
+
+        class M extends E<T>.@MyAnnotation("f") F {
+        }
+    }
+
+    class EImpl extends E<EImpl> {
+    }
+
+    class N {
+        class O<T> {
+        }
+    }
+
+    private A.B aaa;
+    private @MyAnnotation("a") A.B bbb;
+    private A.@MyAnnotation("b") B ccc;
+
+    private C<String>.D ddd;
+    private @MyAnnotation("c") C<String>.D eee;
+    private C<@MyAnnotation("c.t") String>.D fff;
+    private C<String>.@MyAnnotation("d") D ggg;
+
+    private E<EImpl>.F hhh;
+    private @MyAnnotation("e") E<EImpl>.F iii;
+    private E<@MyAnnotation("e.t") EImpl>.F jjj;
+    private E<EImpl>.@MyAnnotation("f") F kkk;
+
+    private N.O<String> lll;
+    private @MyAnnotation("n") N.O<String> mmm;
+    private N.@MyAnnotation("o") O<String> nnn;
+    private N.O<@MyAnnotation("o.t") String> ooo;
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(A.class, A.B.class, C.class, C.D.class, E.class, E.F.class, E.G.class, E.H.class,
+                E.I.class, E.J.class, E.K.class, E.L.class, E.M.class, EImpl.class, ParameterizedTypeOwnerTest.class);
+
+        test(index);
+        test(IndexingUtil.roundtrip(index));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(ParameterizedTypeOwnerTest.class);
+
+        Type aaa = clazz.field("aaa").type();
+        assertEquals(Type.Kind.CLASS, aaa.kind());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$A$B", aaa.toString());
+
+        Type bbb = clazz.field("bbb").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals("org.jboss.jandex.test.@MyAnnotation(\"a\") ParameterizedTypeOwnerTest$A.B", bbb.toString());
+        assertNotNull(bbb.asParameterizedType().owner());
+        assertEquals(Type.Kind.CLASS, bbb.asParameterizedType().owner().kind());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"a\") ParameterizedTypeOwnerTest$A",
+                bbb.asParameterizedType().owner().toString());
+
+        Type ccc = clazz.field("ccc").type();
+        assertEquals(Type.Kind.CLASS, ccc.kind());
+        assertEquals("org.jboss.jandex.test.@MyAnnotation(\"b\") ParameterizedTypeOwnerTest$A$B", ccc.toString());
+
+        Type ddd = clazz.field("ddd").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$C<java.lang.String>.D", ddd.toString());
+        assertNotNull(ddd.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$C<java.lang.String>",
+                ddd.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, ddd.asParameterizedType().owner().kind());
+        assertNull(ddd.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type eee = clazz.field("eee").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"c\") ParameterizedTypeOwnerTest$C<java.lang.String>.D",
+                eee.toString());
+        assertNotNull(eee.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"c\") ParameterizedTypeOwnerTest$C<java.lang.String>",
+                eee.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, eee.asParameterizedType().owner().kind());
+        assertNull(eee.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type fff = clazz.field("fff").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$C<java.lang.@MyAnnotation(\"c.t\") String>.D",
+                fff.toString());
+        assertNotNull(fff.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$C<java.lang.@MyAnnotation(\"c.t\") String>",
+                fff.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, fff.asParameterizedType().owner().kind());
+        assertNull(fff.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type ggg = clazz.field("ggg").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$C<java.lang.String>.@MyAnnotation(\"d\") D",
+                ggg.toString());
+        assertNotNull(ggg.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$C<java.lang.String>",
+                ggg.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, ggg.asParameterizedType().owner().kind());
+        assertNull(ggg.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type hhh = clazz.field("hhh").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.ParameterizedTypeOwnerTest$EImpl>.F",
+                hhh.toString());
+        assertNotNull(hhh.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.ParameterizedTypeOwnerTest$EImpl>",
+                hhh.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, hhh.asParameterizedType().owner().kind());
+        assertNull(hhh.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type iii = clazz.field("iii").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"e\") ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.ParameterizedTypeOwnerTest$EImpl>.F",
+                iii.toString());
+        assertNotNull(iii.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"e\") ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.ParameterizedTypeOwnerTest$EImpl>",
+                iii.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, iii.asParameterizedType().owner().kind());
+        assertNull(iii.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type jjj = clazz.field("jjj").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.@MyAnnotation(\"e.t\") ParameterizedTypeOwnerTest$EImpl>.F",
+                jjj.toString());
+        assertNotNull(jjj.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.@MyAnnotation(\"e.t\") ParameterizedTypeOwnerTest$EImpl>",
+                jjj.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, jjj.asParameterizedType().owner().kind());
+        assertNull(jjj.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type kkk = clazz.field("kkk").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.ParameterizedTypeOwnerTest$EImpl>.@MyAnnotation(\"f\") F",
+                kkk.toString());
+        assertNotNull(kkk.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<org.jboss.jandex.test.ParameterizedTypeOwnerTest$EImpl>",
+                kkk.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, kkk.asParameterizedType().owner().kind());
+        assertNull(kkk.asParameterizedType().owner().asParameterizedType().owner());
+
+        Type lll = clazz.field("lll").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$N$O<java.lang.String>",
+                lll.toString());
+        assertNull(lll.asParameterizedType().owner());
+
+        Type mmm = clazz.field("mmm").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"n\") ParameterizedTypeOwnerTest$N.O<java.lang.String>",
+                mmm.toString());
+        assertNotNull(mmm.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"n\") ParameterizedTypeOwnerTest$N",
+                mmm.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.CLASS, mmm.asParameterizedType().owner().kind());
+
+        Type nnn = clazz.field("nnn").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"o\") ParameterizedTypeOwnerTest$N$O<java.lang.String>",
+                nnn.toString());
+        assertNull(nnn.asParameterizedType().owner());
+
+        Type ooo = clazz.field("ooo").type();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bbb.kind());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$N$O<java.lang.@MyAnnotation(\"o.t\") String>",
+                ooo.toString());
+        assertNull(ooo.asParameterizedType().owner());
+
+        // ---
+
+        Type g = index.getClassByName(E.G.class).superClassType();
+        assertEquals(Type.Kind.CLASS, g.kind());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$E$F", g.toString());
+
+        Type h = index.getClassByName(E.H.class).superClassType();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, h.kind());
+        assertEquals("org.jboss.jandex.test.@MyAnnotation(\"e\") ParameterizedTypeOwnerTest$E.F", h.toString());
+        assertNotNull(h.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"e\") ParameterizedTypeOwnerTest$E",
+                h.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.CLASS, h.asParameterizedType().owner().kind());
+
+        Type i = index.getClassByName(E.I.class).superClassType();
+        assertEquals(Type.Kind.CLASS, i.kind());
+        assertEquals("org.jboss.jandex.test.@MyAnnotation(\"f\") ParameterizedTypeOwnerTest$E$F", i.toString());
+
+        Type j = index.getClassByName(E.J.class).superClassType();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, j.kind());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>.F", j.toString());
+        assertNotNull(j.asParameterizedType().owner());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>", j.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, j.asParameterizedType().owner().kind());
+        assertNull(j.asParameterizedType().owner().asParameterizedType().owner());
+        assertEquals(1, j.asParameterizedType().owner().asParameterizedType().arguments().size());
+        assertEquals(
+                "T extends org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                j.asParameterizedType().owner().asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE, j.asParameterizedType().owner().asParameterizedType().arguments().get(0).kind());
+        assertEquals(1, j.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().size());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, j.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).kind());
+        assertEquals(1, j.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, j.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).kind());
+
+        Type k = index.getClassByName(E.K.class).superClassType();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, k.kind());
+        assertEquals("org.jboss.jandex.test.@MyAnnotation(\"e\") ParameterizedTypeOwnerTest$E<T>.F", k.toString());
+        assertNotNull(k.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.@MyAnnotation(\"e\") ParameterizedTypeOwnerTest$E<T>",
+                k.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, k.asParameterizedType().owner().kind());
+        assertNull(k.asParameterizedType().owner().asParameterizedType().owner());
+        assertEquals(1, k.asParameterizedType().owner().asParameterizedType().arguments().size());
+        assertEquals(
+                "T extends org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                k.asParameterizedType().owner().asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE, k.asParameterizedType().owner().asParameterizedType().arguments().get(0).kind());
+        assertEquals(1, k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().size());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                        .asTypeVariable().bounds().get(0).toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).kind());
+        assertEquals(1, k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().size());
+        assertEquals("T", k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).kind());
+
+        Type l = index.getClassByName(E.L.class).superClassType();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, l.kind());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<@MyAnnotation(\"e.t\") T>.F", l.toString());
+        assertNotNull(l.asParameterizedType().owner());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<@MyAnnotation(\"e.t\") T>",
+                l.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, l.asParameterizedType().owner().kind());
+        assertNull(l.asParameterizedType().owner().asParameterizedType().owner());
+        assertEquals(1, l.asParameterizedType().owner().asParameterizedType().arguments().size());
+        assertEquals(
+                "@MyAnnotation(\"e.t\") T extends org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                l.asParameterizedType().owner().asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE, l.asParameterizedType().owner().asParameterizedType().arguments().get(0).kind());
+        assertEquals(1, l.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().size());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                        .asTypeVariable().bounds().get(0).toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, l.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).kind());
+        assertEquals(1, l.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().size());
+        assertEquals("T", l.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, l.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).kind());
+
+        Type m = index.getClassByName(E.M.class).superClassType();
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, m.kind());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>.@MyAnnotation(\"f\") F", m.toString());
+        assertNotNull(m.asParameterizedType().owner());
+        assertEquals("org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>", m.asParameterizedType().owner().toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, m.asParameterizedType().owner().kind());
+        assertNull(m.asParameterizedType().owner().asParameterizedType().owner());
+        assertEquals(1, m.asParameterizedType().owner().asParameterizedType().arguments().size());
+        assertEquals(
+                "T extends org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                m.asParameterizedType().owner().asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE, m.asParameterizedType().owner().asParameterizedType().arguments().get(0).kind());
+        assertEquals(1, m.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().size());
+        assertEquals(
+                "org.jboss.jandex.test.ParameterizedTypeOwnerTest$E<T>",
+                k.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                        .asTypeVariable().bounds().get(0).toString());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, m.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).kind());
+        assertEquals(1, m.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().size());
+        assertEquals("T", m.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).toString());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, m.asParameterizedType().owner().asParameterizedType().arguments().get(0)
+                .asTypeVariable().bounds().get(0).asParameterizedType().arguments().get(0).kind());
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/RecursiveTypeParametersTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/RecursiveTypeParametersTest.java
@@ -1,0 +1,312 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.function.Consumer;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class RecursiveTypeParametersTest {
+    static class MyComparable<T extends Comparable<T>> {
+    }
+
+    static class DeepTypeParameterReference<T extends Collection<List<Queue<Map<? super T[][], Iterable<? extends T>>>>>> {
+    }
+
+    abstract static class MyEnum<T extends MyEnum<T>> implements Comparable<T> {
+        abstract int ordinal();
+
+        @Override
+        public int compareTo(T other) {
+            return Integer.compare(this.ordinal(), other.ordinal());
+        }
+    }
+
+    abstract static class MyBuilder<T, THIS extends MyBuilder<T, THIS>> {
+        abstract T build();
+
+        final THIS self() {
+            return (THIS) this;
+        }
+
+        final THIS with(Consumer<THIS> action) {
+            action.accept(self());
+            return self();
+        }
+    }
+
+    interface Score<S extends Score<S>> {
+    }
+
+    static class ScoreManager<S extends Score<S>> {
+    }
+
+    static class ScoreManagerFactory {
+        <S extends Score<S>> ScoreManager<S> newScoreManager() {
+            return new ScoreManager<>();
+        }
+    }
+
+    // ---
+
+    @Test
+    public void myComparable() throws IOException {
+        Index index = Index.of(MyComparable.class);
+        myComparable(index);
+        myComparable(IndexingUtil.roundtrip(index));
+    }
+
+    private void myComparable(Index index) {
+        ClassInfo clazz = index.getClassByName(MyComparable.class);
+        List<TypeVariable> typeParams = clazz.typeParameters();
+        assertEquals(1, typeParams.size());
+        TypeVariable typeParam = typeParams.get(0);
+        assertEquals("T", typeParam.identifier());
+        assertEquals(1, typeParam.bounds().size());
+        Type bound = typeParam.bounds().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+        assertEquals(DotName.createSimple(Comparable.class.getName()), bound.asParameterizedType().name());
+        assertEquals(1, bound.asParameterizedType().arguments().size());
+        Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, boundTypeArg.kind());
+        assertEquals("T", boundTypeArg.asTypeVariableReference().identifier());
+        assertNotNull(boundTypeArg.asTypeVariableReference().follow());
+        assertSame(typeParam, boundTypeArg.asTypeVariableReference().follow());
+        assertEquals("T extends java.lang.Comparable<T>", typeParam.toString());
+    }
+
+    @Test
+    public void deepTypeParameterReference() throws IOException {
+        Index index = Index.of(DeepTypeParameterReference.class);
+        deepTypeParameterReference(index);
+        deepTypeParameterReference(IndexingUtil.roundtrip(index));
+    }
+
+    private void deepTypeParameterReference(Index index) {
+        ClassInfo clazz = index.getClassByName(DeepTypeParameterReference.class);
+        List<TypeVariable> typeParams = clazz.typeParameters();
+        assertEquals(1, typeParams.size());
+        TypeVariable typeParam = typeParams.get(0);
+        assertEquals("T", typeParam.identifier());
+        assertEquals(1, typeParam.bounds().size());
+
+        Type bound = typeParam.bounds().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+        assertEquals(DotName.createSimple(Collection.class.getName()), bound.asParameterizedType().name());
+        assertEquals(1, bound.asParameterizedType().arguments().size());
+
+        Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, boundTypeArg.kind());
+        assertEquals(DotName.createSimple(List.class.getName()), boundTypeArg.asParameterizedType().name());
+        assertEquals(1, boundTypeArg.asParameterizedType().arguments().size());
+
+        Type nestedTypeArg = boundTypeArg.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, nestedTypeArg.kind());
+        assertEquals(DotName.createSimple(Queue.class.getName()), nestedTypeArg.asParameterizedType().name());
+        assertEquals(1, nestedTypeArg.asParameterizedType().arguments().size());
+
+        Type nestedNestedTypeArg = nestedTypeArg.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, nestedNestedTypeArg.kind());
+        assertEquals(DotName.createSimple(Map.class.getName()), nestedNestedTypeArg.asParameterizedType().name());
+        assertEquals(2, nestedNestedTypeArg.asParameterizedType().arguments().size());
+
+        {
+            Type key = nestedNestedTypeArg.asParameterizedType().arguments().get(0);
+            assertEquals(DotName.OBJECT_NAME, key.name()); // has lower bound, so upper bound is java.lang.Object
+            assertEquals(Type.Kind.WILDCARD_TYPE, key.kind());
+            assertNotNull(key.asWildcardType().superBound());
+
+            Type keyBound = key.asWildcardType().superBound();
+            assertEquals(Type.Kind.ARRAY, keyBound.kind());
+            assertEquals(DotName.createSimple("[[Ljava.util.Collection;"), keyBound.name());
+            assertEquals(2, keyBound.asArrayType().dimensions());
+
+            Type keyBoundComponent = keyBound.asArrayType().component();
+            assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, keyBoundComponent.kind());
+            assertEquals(DotName.createSimple(Collection.class.getName()), keyBoundComponent.name());
+            assertEquals("T", keyBoundComponent.asTypeVariableReference().identifier());
+            assertNotNull(keyBoundComponent.asTypeVariableReference().follow());
+            assertSame(typeParam, keyBoundComponent.asTypeVariableReference().follow());
+        }
+
+        {
+            Type value = nestedNestedTypeArg.asParameterizedType().arguments().get(1);
+            assertEquals(DotName.createSimple(Iterable.class.getName()), value.name()); // upper bound
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, value.kind());
+            assertEquals(1, value.asParameterizedType().arguments().size());
+
+            Type valueTypeArg = value.asParameterizedType().arguments().get(0);
+            assertEquals(Type.Kind.WILDCARD_TYPE, valueTypeArg.kind());
+            assertNull(valueTypeArg.asWildcardType().superBound());
+
+            Type valueTypeArgBound = valueTypeArg.asWildcardType().extendsBound();
+            assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, valueTypeArgBound.kind());
+            assertEquals(DotName.createSimple(Collection.class.getName()), valueTypeArgBound.name());
+            assertEquals("T", valueTypeArgBound.asTypeVariableReference().identifier());
+            assertNotNull(valueTypeArgBound.asTypeVariableReference().follow());
+            assertSame(typeParam, valueTypeArgBound.asTypeVariableReference().follow());
+        }
+
+        assertEquals(
+                "T extends java.util.Collection<java.util.List<java.util.Queue<java.util.Map<? super T[][], java.lang.Iterable<? extends T>>>>>",
+                typeParam.toString());
+    }
+
+    @Test
+    public void myEnum() throws IOException {
+        Index index = Index.of(MyEnum.class);
+        myEnum(index);
+        myEnum(IndexingUtil.roundtrip(index));
+    }
+
+    private void myEnum(Index index) {
+        ClassInfo clazz = index.getClassByName(MyEnum.class);
+        List<TypeVariable> typeParams = clazz.typeParameters();
+        assertEquals(1, typeParams.size());
+        TypeVariable typeParam = typeParams.get(0);
+        assertEquals("T", typeParam.identifier());
+        assertEquals(1, typeParam.bounds().size());
+        Type bound = typeParam.bounds().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+        assertEquals(DotName.createSimple(MyEnum.class.getName()), bound.asParameterizedType().name());
+        assertEquals(1, bound.asParameterizedType().arguments().size());
+        Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, boundTypeArg.kind());
+        assertEquals("T", boundTypeArg.asTypeVariableReference().identifier());
+        assertNotNull(boundTypeArg.asTypeVariableReference().follow());
+        assertSame(typeParam, boundTypeArg.asTypeVariableReference().follow());
+
+        assertEquals("T extends org.jboss.jandex.test.RecursiveTypeParametersTest$MyEnum<T>", typeParam.toString());
+    }
+
+    @Test
+    public void myBuilder() throws IOException {
+        Index index = Index.of(MyBuilder.class);
+        myBuilder(index);
+        myBuilder(IndexingUtil.roundtrip(index));
+    }
+
+    private void myBuilder(Index index) {
+        ClassInfo clazz = index.getClassByName(MyBuilder.class);
+        List<TypeVariable> typeParams = clazz.typeParameters();
+        assertEquals(2, typeParams.size());
+        {
+            TypeVariable typeParam = typeParams.get(0);
+            assertEquals("T", typeParam.identifier());
+            assertEquals(1, typeParam.bounds().size());
+            assertEquals(DotName.OBJECT_NAME, typeParam.bounds().get(0).name());
+        }
+        {
+            TypeVariable typeParam = typeParams.get(1);
+            assertMyBuilderRecursiveTypeParameter(typeParam);
+        }
+
+        {
+            MethodInfo method = clazz.firstMethod("self");
+            assertEquals(Type.Kind.TYPE_VARIABLE, method.returnType().kind());
+            assertMyBuilderRecursiveTypeParameter(method.returnType().asTypeVariable());
+        }
+
+        {
+            MethodInfo method = clazz.firstMethod("with");
+            assertEquals(Type.Kind.TYPE_VARIABLE, method.returnType().kind());
+            assertMyBuilderRecursiveTypeParameter(method.returnType().asTypeVariable());
+
+            Type parameter = method.parameterType(0);
+            assertEquals(DotName.createSimple(Consumer.class.getName()), parameter.name());
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, parameter.kind());
+            assertEquals(1, parameter.asParameterizedType().arguments().size());
+            Type typeArgument = parameter.asParameterizedType().arguments().get(0);
+            assertEquals(Type.Kind.TYPE_VARIABLE, typeArgument.kind());
+            assertMyBuilderRecursiveTypeParameter(typeArgument.asTypeVariable());
+        }
+
+        assertEquals("T", typeParams.get(0).toString());
+        assertEquals(
+                "THIS extends org.jboss.jandex.test.RecursiveTypeParametersTest$MyBuilder<T, THIS>",
+                typeParams.get(1).toString());
+    }
+
+    private void assertMyBuilderRecursiveTypeParameter(TypeVariable typeVariable) {
+        assertEquals("THIS", typeVariable.identifier());
+        assertEquals(1, typeVariable.bounds().size());
+        Type bound = typeVariable.bounds().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+        assertEquals(DotName.createSimple(MyBuilder.class.getName()), bound.asParameterizedType().name());
+        assertEquals(2, bound.asParameterizedType().arguments().size());
+        {
+            Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+            assertEquals(Type.Kind.TYPE_VARIABLE, boundTypeArg.kind());
+            assertEquals("T", boundTypeArg.asTypeVariable().identifier());
+            assertEquals(1, boundTypeArg.asTypeVariable().bounds().size());
+            assertEquals(DotName.OBJECT_NAME, boundTypeArg.asTypeVariable().bounds().get(0).name());
+        }
+        {
+            Type boundTypeArg = bound.asParameterizedType().arguments().get(1);
+            assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, boundTypeArg.kind());
+            assertEquals("THIS", boundTypeArg.asTypeVariableReference().identifier());
+            assertNotNull(boundTypeArg.asTypeVariableReference().follow());
+            assertSame(typeVariable, boundTypeArg.asTypeVariableReference().follow());
+        }
+    }
+
+    @Test
+    public void score() throws IOException {
+        Index index = Index.of(Score.class, ScoreManager.class, ScoreManagerFactory.class);
+        score(index);
+        score(IndexingUtil.roundtrip(index));
+    }
+
+    private void score(Index index) {
+        ClassInfo scoreManagerFactory = index.getClassByName(ScoreManagerFactory.class);
+        MethodInfo newScoreManager = scoreManagerFactory.method("newScoreManager");
+        Type type = newScoreManager.returnType();
+        assertEquals(DotName.createSimple(ScoreManager.class.getName()), type.name());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, type.kind());
+        assertScoreTypeVariable(type.asParameterizedType().arguments().get(0));
+
+        ClassInfo scoreManager = index.getClassByName(ScoreManager.class);
+        assertEquals(1, scoreManager.typeParameters().size());
+        assertScoreTypeVariable(scoreManager.typeParameters().get(0));
+
+        ClassInfo score = index.getClassByName(Score.class);
+        assertEquals(1, score.typeParameters().size());
+        assertScoreTypeVariable(score.typeParameters().get(0));
+    }
+
+    private void assertScoreTypeVariable(Type typeVariable) {
+        // S extends Score<S>
+        assertEquals(DotName.createSimple(Score.class.getName()), typeVariable.name());
+        assertEquals(Type.Kind.TYPE_VARIABLE, typeVariable.kind());
+        assertEquals("S", typeVariable.asTypeVariable().identifier());
+
+        // Score<S>
+        Type bound = typeVariable.asTypeVariable().bounds().get(0);
+        assertEquals(DotName.createSimple(Score.class.getName()), bound.name());
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+
+        // S, which is a reference to S extends Score<S>
+        Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+        assertEquals(DotName.createSimple(Score.class.getName()), boundTypeArg.name());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, boundTypeArg.kind());
+
+        assertSame(typeVariable, boundTypeArg.asTypeVariableReference().follow());
+
+        assertEquals("S extends org.jboss.jandex.test.RecursiveTypeParametersTest$Score<S>", typeVariable.toString());
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/RecursiveTypeParametersWithAnnotationsTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/RecursiveTypeParametersWithAnnotationsTest.java
@@ -1,0 +1,229 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class RecursiveTypeParametersWithAnnotationsTest {
+    static class MyComparable<@MyAnnotation("1") T extends @MyAnnotation("2") Comparable<@MyAnnotation("3") T>> {
+    }
+
+    static class MyBuilder<@MyAnnotation("1") T, @MyAnnotation("2") THIS extends @MyAnnotation("3") MyBuilder<@MyAnnotation("4") T, @MyAnnotation("5") THIS>> {
+    }
+
+    static class DeepTypeParameterReference<@MyAnnotation("1") T extends @MyAnnotation("2") Collection<@MyAnnotation("3") List<@MyAnnotation("4") Queue<@MyAnnotation("5") Map<@MyAnnotation("6") ? super @MyAnnotation("7") T[] @MyAnnotation("8") [], @MyAnnotation("9") Iterable<@MyAnnotation("10") ? extends @MyAnnotation("11") T>>>>>> {
+    }
+
+    @Test
+    public void myComparable() throws IOException {
+        Index index = Index.of(MyComparable.class);
+        myComparable(index);
+        myComparable(IndexingUtil.roundtrip(index));
+    }
+
+    private void myComparable(Index index) {
+        ClassInfo clazz = index.getClassByName(MyComparable.class);
+        List<TypeVariable> typeParams = clazz.typeParameters();
+        assertEquals(1, typeParams.size());
+        TypeVariable typeParam = typeParams.get(0);
+        assertEquals("T", typeParam.identifier());
+        assertTypeAnnotation(typeParam, "1");
+
+        assertEquals(1, typeParam.bounds().size());
+        Type bound = typeParam.bounds().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+        assertEquals(DotName.createSimple(Comparable.class.getName()), bound.asParameterizedType().name());
+        assertEquals(1, bound.asParameterizedType().arguments().size());
+        assertTypeAnnotation(bound, "2");
+
+        Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, boundTypeArg.kind());
+        assertEquals("T", boundTypeArg.asTypeVariableReference().identifier());
+        assertNotNull(boundTypeArg.asTypeVariableReference().follow());
+        assertTypeAnnotation(boundTypeArg, "3");
+        assertSame(typeParam, boundTypeArg.asTypeVariableReference().follow());
+
+        assertEquals(
+                "@MyAnnotation(\"1\") T extends java.lang.@MyAnnotation(\"2\") Comparable<@MyAnnotation(\"3\") T>",
+                typeParam.toString());
+    }
+
+    @Test
+    public void myBuilder() throws IOException {
+        Index index = Index.of(MyBuilder.class);
+        myBuilder(index);
+        myBuilder(IndexingUtil.roundtrip(index));
+    }
+
+    private void myBuilder(Index index) {
+        ClassInfo clazz = index.getClassByName(MyBuilder.class);
+        assertEquals(2, clazz.typeParameters().size());
+
+        {
+            TypeVariable typeParam = clazz.typeParameters().get(0);
+            assertEquals("T", typeParam.identifier());
+            assertTypeAnnotation(typeParam, "1");
+
+            assertEquals(1, typeParam.bounds().size());
+            assertEquals(Type.Kind.CLASS, typeParam.bounds().get(0).kind());
+            assertEquals(DotName.OBJECT_NAME, typeParam.bounds().get(0).name());
+        }
+
+        {
+            TypeVariable typeParam = clazz.typeParameters().get(1);
+            assertEquals("THIS", typeParam.identifier());
+            assertTypeAnnotation(typeParam, "2");
+
+            assertEquals(1, typeParam.bounds().size());
+            Type bound = typeParam.bounds().get(0);
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+            assertEquals(DotName.createSimple(MyBuilder.class.getName()), bound.name());
+            assertTypeAnnotation(bound, "3");
+
+            assertEquals(2, bound.asParameterizedType().arguments().size());
+
+            {
+                Type typeArg = bound.asParameterizedType().arguments().get(0);
+                assertEquals(Type.Kind.TYPE_VARIABLE, typeArg.kind());
+                assertEquals("T", typeArg.asTypeVariable().identifier());
+                assertTypeAnnotation(typeArg, "4");
+
+                assertEquals(1, typeArg.asTypeVariable().bounds().size());
+                assertEquals(Type.Kind.CLASS, typeArg.asTypeVariable().bounds().get(0).kind());
+                assertEquals(DotName.OBJECT_NAME, typeArg.asTypeVariable().bounds().get(0).name());
+            }
+
+            {
+                Type typeArg = bound.asParameterizedType().arguments().get(1);
+                assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, typeArg.kind());
+                assertEquals("THIS", typeArg.asTypeVariableReference().identifier());
+                assertTypeAnnotation(typeArg, "5");
+
+                assertSame(typeParam, typeArg.asTypeVariableReference().follow());
+            }
+        }
+
+        assertEquals("@MyAnnotation(\"1\") T", clazz.typeParameters().get(0).toString());
+        assertEquals(
+                "@MyAnnotation(\"2\") THIS extends org.jboss.jandex.test.@MyAnnotation(\"3\") RecursiveTypeParametersWithAnnotationsTest$MyBuilder<@MyAnnotation(\"4\") T, @MyAnnotation(\"5\") THIS>",
+                clazz.typeParameters().get(1).toString());
+    }
+
+    @Test
+    public void deepTypeParameterReference() throws IOException {
+        Index index = Index.of(DeepTypeParameterReference.class);
+        deepTypeParameterReference(index);
+        deepTypeParameterReference(IndexingUtil.roundtrip(index));
+    }
+
+    private void deepTypeParameterReference(Index index) {
+        ClassInfo clazz = index.getClassByName(DeepTypeParameterReference.class);
+        List<TypeVariable> typeParams = clazz.typeParameters();
+        assertEquals(1, typeParams.size());
+        TypeVariable typeParam = typeParams.get(0);
+        assertEquals("T", typeParam.identifier());
+        assertEquals(1, typeParam.bounds().size());
+        assertTypeAnnotation(typeParam, "1");
+
+        Type bound = typeParam.bounds().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, bound.kind());
+        assertEquals(DotName.createSimple(Collection.class.getName()), bound.asParameterizedType().name());
+        assertEquals(1, bound.asParameterizedType().arguments().size());
+        assertTypeAnnotation(bound, "2");
+
+        Type boundTypeArg = bound.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, boundTypeArg.kind());
+        assertEquals(DotName.createSimple(List.class.getName()), boundTypeArg.asParameterizedType().name());
+        assertEquals(1, boundTypeArg.asParameterizedType().arguments().size());
+        assertTypeAnnotation(boundTypeArg, "3");
+
+        Type nestedTypeArg = boundTypeArg.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, nestedTypeArg.kind());
+        assertEquals(DotName.createSimple(Queue.class.getName()), nestedTypeArg.asParameterizedType().name());
+        assertEquals(1, nestedTypeArg.asParameterizedType().arguments().size());
+        assertTypeAnnotation(nestedTypeArg, "4");
+
+        Type nestedNestedTypeArg = nestedTypeArg.asParameterizedType().arguments().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, nestedNestedTypeArg.kind());
+        assertEquals(DotName.createSimple(Map.class.getName()), nestedNestedTypeArg.asParameterizedType().name());
+        assertEquals(2, nestedNestedTypeArg.asParameterizedType().arguments().size());
+        assertTypeAnnotation(nestedNestedTypeArg, "5");
+
+        {
+            Type key = nestedNestedTypeArg.asParameterizedType().arguments().get(0);
+            assertEquals(DotName.OBJECT_NAME, key.name()); // has lower bound, so upper bound is java.lang.Object
+            assertEquals(Type.Kind.WILDCARD_TYPE, key.kind());
+            assertNotNull(key.asWildcardType().superBound());
+            assertTypeAnnotation(key, "6");
+
+            Type keyBound = key.asWildcardType().superBound();
+            assertEquals(Type.Kind.ARRAY, keyBound.kind());
+            assertEquals(DotName.createSimple("[[Ljava.util.Collection;"), keyBound.name());
+            assertEquals(1, keyBound.asArrayType().dimensions());
+            assertFalse(keyBound.hasAnnotation(MyAnnotation.DOT_NAME));
+
+            Type keyBoundComponent = keyBound.asArrayType().component();
+            assertEquals(Type.Kind.ARRAY, keyBoundComponent.kind());
+            assertEquals(DotName.createSimple("[Ljava.util.Collection;"), keyBoundComponent.name());
+            assertEquals(1, keyBoundComponent.asArrayType().dimensions());
+            assertTypeAnnotation(keyBoundComponent, "8");
+
+            Type keyBoundComponentComponent = keyBoundComponent.asArrayType().component();
+            assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, keyBoundComponentComponent.kind());
+            assertEquals(DotName.createSimple(Collection.class.getName()), keyBoundComponentComponent.name());
+            assertEquals("T", keyBoundComponentComponent.asTypeVariableReference().identifier());
+            assertNotNull(keyBoundComponentComponent.asTypeVariableReference().follow());
+            assertTypeAnnotation(keyBoundComponentComponent, "7");
+
+            assertSame(typeParam, keyBoundComponentComponent.asTypeVariableReference().follow());
+        }
+
+        {
+            Type value = nestedNestedTypeArg.asParameterizedType().arguments().get(1);
+            assertEquals(DotName.createSimple(Iterable.class.getName()), value.name()); // upper bound
+            assertEquals(Type.Kind.PARAMETERIZED_TYPE, value.kind());
+            assertEquals(1, value.asParameterizedType().arguments().size());
+            assertTypeAnnotation(value, "9");
+
+            Type valueTypeArg = value.asParameterizedType().arguments().get(0);
+            assertEquals(Type.Kind.WILDCARD_TYPE, valueTypeArg.kind());
+            assertNull(valueTypeArg.asWildcardType().superBound());
+            assertTypeAnnotation(valueTypeArg, "10");
+
+            Type valueTypeArgBound = valueTypeArg.asWildcardType().extendsBound();
+            assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, valueTypeArgBound.kind());
+            assertEquals(DotName.createSimple(Collection.class.getName()), valueTypeArgBound.name());
+            assertEquals("T", valueTypeArgBound.asTypeVariableReference().identifier());
+            assertNotNull(valueTypeArgBound.asTypeVariableReference().follow());
+            assertTypeAnnotation(valueTypeArgBound, "11");
+
+            assertSame(typeParam, valueTypeArgBound.asTypeVariableReference().follow());
+        }
+
+        assertEquals(
+                "@MyAnnotation(\"1\") T extends java.util.@MyAnnotation(\"2\") Collection<java.util.@MyAnnotation(\"3\") List<java.util.@MyAnnotation(\"4\") Queue<java.util.@MyAnnotation(\"5\") Map<@MyAnnotation(\"6\") ? super @MyAnnotation(\"7\") T[] @MyAnnotation(\"8\") [], java.lang.@MyAnnotation(\"9\") Iterable<@MyAnnotation(\"10\") ? extends @MyAnnotation(\"11\") T>>>>>",
+                typeParam.toString());
+    }
+
+    private void assertTypeAnnotation(Type type, String expectedValue) {
+        assertTrue(type.hasAnnotation(MyAnnotation.DOT_NAME));
+        assertEquals(expectedValue, type.annotation(MyAnnotation.DOT_NAME).value().asString());
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnMethodTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnMethodTest.java
@@ -1,10 +1,12 @@
 package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
 import org.junit.jupiter.api.Test;
 
 public class SignatureSharingOnMethodTest {
@@ -32,11 +34,14 @@ public class SignatureSharingOnMethodTest {
 
     private void test(Index index) {
         ClassInfo clazz = index.getClassByName(WithMethodSignature.class);
-        Type typeVariable = clazz.firstMethod("method").returnType().asTypeVariable() // E extends Comparable<E>
+        TypeVariable typeVariable = clazz.firstMethod("method").returnType().asTypeVariable(); // E extends Comparable<E>
+
+        Type reference = typeVariable
                 .bounds().get(0).asParameterizedType() // Comparable<E>
                 .arguments().get(0); // E
 
-        assertEquals(Type.Kind.UNRESOLVED_TYPE_VARIABLE, typeVariable.kind());
-        assertEquals("E", typeVariable.asUnresolvedTypeVariable().identifier());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, reference.kind());
+        assertEquals("E", reference.asTypeVariableReference().identifier());
+        assertSame(typeVariable, reference.asTypeVariableReference().follow());
     }
 }

--- a/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnOwnClassTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnOwnClassTest.java
@@ -1,10 +1,12 @@
 package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
 import org.junit.jupiter.api.Test;
 
 public class SignatureSharingOnOwnClassTest {
@@ -16,11 +18,14 @@ public class SignatureSharingOnOwnClassTest {
     public void test() throws Exception {
         Index index = Index.of(WithSignatures.class);
         ClassInfo clazz = index.getClassByName(WithSignatures.class);
-        Type typeVariable = clazz.firstMethod("method").returnType().asTypeVariable() // E extends Comparable<E>
+        TypeVariable typeVariable = clazz.firstMethod("method").returnType().asTypeVariable(); // E extends Comparable<E>
+
+        Type reference = typeVariable
                 .bounds().get(0).asParameterizedType() // Comparable<E>
                 .arguments().get(0); // E
 
-        assertEquals(Type.Kind.UNRESOLVED_TYPE_VARIABLE, typeVariable.kind());
-        assertEquals("E", typeVariable.asUnresolvedTypeVariable().identifier());
+        assertEquals(Type.Kind.TYPE_VARIABLE_REFERENCE, reference.kind());
+        assertEquals("E", reference.asTypeVariableReference().identifier());
+        assertSame(typeVariable, reference.asTypeVariableReference().follow());
     }
 }


### PR DESCRIPTION
This commit adds a new kind of type, a `TypeVariableReference`, which is used
in a class/method list of type parameters to represent a type variable that
isn't fully defined yet. For simple recursive type parameters, such as
`T extends Comparable<T>`, this naturally means that type variables occurring
in their own definitions are represented as references. For mutually recursive
type parameters, type variables that occur in their definitions or before their
definitions are represented as references. A type variable reference can be
`follow()`-ed to obtain the underlying type variable.

The `TypeVariableReference` is mutable, initially points to `null` and must
later be patched. This occurs on several occasions:

1. When indexing a class, generic signatures are parsed, which includes
   resolution of type variables (where unresolved type variables that are
   found recursive are replaced by references) and then patching of newly
   introduced references.
2. Whe completing an index, type annotations are propagated, which includes
   creating deep copies of type variables that include references. To create
   such deep copies, new references are introduced, to avoid sharing. Such
   new references are later patched.
3. When deserializing an index, types are read in topological order (if a type
   is composite, it is read after its constituent types), which also requires
   patching references (because they are read earlier).

This change requires persistent format version bump. That has already
happened on the `smallrye` branch, so this commit doesn't bump again,
but note that this commit can't be backported to Jandex 2.x.

Resolves #88