### PR TITLE
Backport some Jandex 3.0 methods to 2.4

### DIFF
--- a/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -309,12 +309,28 @@ public final class ClassInfo implements AnnotationTarget {
      * Returns a map indexed by annotation name, with a value list of annotation instances.
      * The annotation instances in this map correspond to both annotations on the class,
      * and every nested element of the class (fields, types, methods, etc).
+     * <p>
+     * The target of the annotation instance can be used to determine the location of
+     * the annotation usage.
+     *
+     * @return immutable map of annotations specified on this class and its elements, never {@code null}
+     */
+    public final Map<DotName, List<AnnotationInstance>> annotationsMap() {
+        return Collections.unmodifiableMap(annotations);
+    }
+
+    /**
+     * Returns a map indexed by annotation name, with a value list of annotation instances.
+     * The annotation instances in this map correspond to both annotations on the class,
+     * and every nested element of the class (fields, types, methods, etc).
      *
      * <p>The target of the annotation instance can be used to determine the location of
      * the annotation usage.</p>
      *
+     * @deprecated this method will have a different return type in Jandex 3.0, use {@link #annotationsMap()} instead
      * @return the annotations specified on this class and its elements
      */
+    @Deprecated
     public final Map<DotName, List<AnnotationInstance>> annotations() {
         return Collections.unmodifiableMap(annotations);
     }

--- a/src/main/java/org/jboss/jandex/IndexWriterV1.java
+++ b/src/main/java/org/jboss/jandex/IndexWriterV1.java
@@ -180,7 +180,7 @@ final class IndexWriterV1 extends IndexWriterImpl {
             for (DotName intf: interfaces)
                 stream.writePackedU32(positionOf(intf));
 
-            Set<Entry<DotName, List<AnnotationInstance>>> entrySet = clazz.annotations().entrySet();
+            Set<Entry<DotName, List<AnnotationInstance>>> entrySet = clazz.annotationsMap().entrySet();
             stream.writePackedU32(entrySet.size());
             for (Entry<DotName, List<AnnotationInstance>> entry :  entrySet) {
                 stream.writePackedU32(positionOf(entry.getKey()));
@@ -308,7 +308,7 @@ final class IndexWriterV1 extends IndexWriterImpl {
             for (DotName intf: clazz.interfaces())
                 addClassName(intf);
 
-            for (Entry<DotName, List<AnnotationInstance>> entry :  clazz.annotations().entrySet()) {
+            for (Entry<DotName, List<AnnotationInstance>> entry :  clazz.annotationsMap().entrySet()) {
                 addClassName(entry.getKey());
 
                 for (AnnotationInstance instance: entry.getValue()) {

--- a/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -592,7 +592,7 @@ final class IndexWriterV2 extends IndexWriterImpl{
         }
 
         // Annotation length is early to allow eager allocation in reader.
-        stream.writePackedU32(clazz.annotations().size());
+        stream.writePackedU32(clazz.annotationsMap().size());
 
         FieldInternal[] fields = clazz.fieldArray();
         stream.writePackedU32(fields.length);
@@ -624,7 +624,7 @@ final class IndexWriterV2 extends IndexWriterImpl{
             stream.writePackedU32(positionOf(clazz.recordComponentPositionArray()));
         }
 
-        Set<Entry<DotName, List<AnnotationInstance>>> entrySet = clazz.annotations().entrySet();
+        Set<Entry<DotName, List<AnnotationInstance>>> entrySet = clazz.annotationsMap().entrySet();
         for (Entry<DotName, List<AnnotationInstance>> entry :  entrySet) {
             List<AnnotationInstance> value = entry.getValue();
             stream.writePackedU32(value.size());
@@ -887,7 +887,7 @@ final class IndexWriterV2 extends IndexWriterImpl{
         addRecordComponentList(clazz.recordComponentArray());
         names.intern(clazz.recordComponentPositionArray());
 
-        for (Entry<DotName, List<AnnotationInstance>> entry :  clazz.annotations().entrySet()) {
+        for (Entry<DotName, List<AnnotationInstance>> entry :  clazz.annotationsMap().entrySet()) {
             addClassName(entry.getKey());
 
             for (AnnotationInstance instance: entry.getValue()) {

--- a/src/main/java/org/jboss/jandex/JarIndexer.java
+++ b/src/main/java/org/jboss/jandex/JarIndexer.java
@@ -226,7 +226,7 @@ public class JarIndexer {
     }
 
     private static void printIndexEntryInfo(ClassInfo info, PrintStream infoStream) {
-        infoStream.println("Indexed " + info.name() + " (" + info.annotations().size() + " annotations)");
+        infoStream.println("Indexed " + info.name() + " (" + info.annotationsMap().size() + " annotations)");
     }
     
     private static void copy(InputStream in, OutputStream out) throws IOException {

--- a/src/main/java/org/jboss/jandex/Main.java
+++ b/src/main/java/org/jboss/jandex/Main.java
@@ -132,7 +132,7 @@ public class Main {
     }
 
     private void printIndexEntryInfo(ClassInfo info) {
-        System.out.println("Indexed " + info.name() + " (" + info.annotations().size() + " annotations)");
+        System.out.println("Indexed " + info.name() + " (" + info.annotationsMap().size() + " annotations)");
     }
 
     private void scanFile(File source, Indexer indexer) throws FileNotFoundException, IOException {

--- a/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -143,11 +143,22 @@ public final class MethodInfo implements AnnotationTarget {
 
     /**
      * Returns the name of the given parameter.
-     * @param i the parameter index
+     *
+     * @param i the parameter index, zero-based
      * @return the name of the given parameter, or null.
      */
     public final String parameterName(int i) {
         return methodInternal.parameterName(i);
+    }
+
+    /**
+     * Returns the type of the given parameter.
+     *
+     * @param i the parameter index, zero-based
+     * @return the type of the given parameter
+     */
+    public final Type parameterType(int i) {
+        return methodInternal.parameterArray()[i];
     }
     
     public final Kind kind() {
@@ -165,7 +176,7 @@ public final class MethodInfo implements AnnotationTarget {
 
     /**
      * Returns an array containing parameter types in parameter order. This method performs a defensive array
-     * copy per call, and should be avoided. Instead the {@link #parameters()} method should be used.
+     * copy per call, and should be avoided. Instead the {@link #parameterTypes()} method should be used.
      *
      * @return an array copy contain parameter types
      */
@@ -179,11 +190,31 @@ public final class MethodInfo implements AnnotationTarget {
     }
 
     /**
+     * Returns the number of parameters this method declares.
+     *
+     * @return the number of parameters this method declares
+     */
+    public final int parametersCount() {
+        return methodInternal.parameterArray().length;
+    }
+
+    /**
+     * Returns a list of types of parameters declared on this method, in declaration order.
+     *
+     * @return immutable list of parameter types of this method, never {@code null}
+     */
+    public final List<Type> parameterTypes() {
+        return methodInternal.parameters();
+    }
+
+    /**
      * Returns a list containing the types of all parameters declared on this method, in parameter order.
      * This method may return an empty list, but never null.
      *
+     * @deprecated this method will have a different return type in Jandex 3.0, use {@link #parameterTypes()} instead
      * @return all parameter types on this method
      */
+    @Deprecated
     public final List<Type> parameters() {
         return methodInternal.parameters();
     }

--- a/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -484,7 +484,7 @@ public class BasicTestCase {
                   Type.create(DotName.createSimple(DummyClass.class.getName()), Type.Kind.CLASS), PrimitiveType.INT);
             assertNotNull(nestedConstructor1);
             // synthetic param counts here
-            assertEquals(2, nestedConstructor1.parameters().size());
+            assertEquals(2, nestedConstructor1.parameterTypes().size());
             // synthetic param does not counts here
             assertEquals("noAnnotation", nestedConstructor1.parameterName(0));
 
@@ -492,7 +492,7 @@ public class BasicTestCase {
                   Type.create(DotName.createSimple(DummyClass.class.getName()), Type.Kind.CLASS), PrimitiveType.BYTE);
             assertNotNull(nestedConstructor2);
             // synthetic param counts here
-            assertEquals(2, nestedConstructor2.parameters().size());
+            assertEquals(2, nestedConstructor2.parameterTypes().size());
             // synthetic param does not counts here
             assertEquals("annotated", nestedConstructor2.parameterName(0));
 
@@ -511,10 +511,10 @@ public class BasicTestCase {
                 enumConstructor1 = enumClass.method("<init>", PrimitiveType.INT);
                 assertNotNull(enumConstructor1);
                 // synthetic param does not found here
-                assertEquals(1, enumConstructor1.parameters().size());
+                assertEquals(1, enumConstructor1.parameterTypes().size());
             }else {
                 // synthetic param counts here
-                assertEquals(3, enumConstructor1.parameters().size());
+                assertEquals(3, enumConstructor1.parameterTypes().size());
             }
             // synthetic param does not counts here
             assertEquals("noAnnotation", enumConstructor1.parameterName(0));
@@ -525,10 +525,10 @@ public class BasicTestCase {
                 enumConstructor2 = enumClass.method("<init>", PrimitiveType.BYTE);
                 assertNotNull(enumConstructor2);
                 // synthetic param does not found here
-                assertEquals(1, enumConstructor2.parameters().size());
+                assertEquals(1, enumConstructor2.parameterTypes().size());
             }else {
                 // synthetic param counts here
-                assertEquals(3, enumConstructor2.parameters().size());
+                assertEquals(3, enumConstructor2.parameterTypes().size());
             }
             // synthetic param does not counts here
             assertEquals("annotated", enumConstructor2.parameterName(0));

--- a/src/test/java/org/jboss/jandex/test/BridgeMethodTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BridgeMethodTestCase.java
@@ -122,7 +122,7 @@ public class BridgeMethodTestCase {
             Type type;
             switch (usage) {
                 case METHOD_PARAMETER:
-                    type = method.parameters().get(0);
+                    type = method.parameterTypes().get(0);
                     break;
                 case EMPTY:
                     type = method.returnType();

--- a/src/test/java/org/jboss/jandex/test/InnerClassTypeAnnotationTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/InnerClassTypeAnnotationTestCase.java
@@ -96,6 +96,6 @@ public class InnerClassTypeAnnotationTestCase {
 
     private void verifyTypeAnnotations(Index index, String name, int pos) {
         ClassInfo clazz = index.getClassByName(DotName.createSimple("test.InnerClassTypeAnnotationsExample$" + name));
-        Assert.assertTrue(clazz.constructors().get(0).parameters().get(pos).hasAnnotation(DotName.createSimple("test.Nullable")));
+        Assert.assertTrue(clazz.constructors().get(0).parameterTypes().get(pos).hasAnnotation(DotName.createSimple("test.Nullable")));
     }
 }

--- a/src/test/java/org/jboss/jandex/test/ModuleInfoTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/ModuleInfoTestCase.java
@@ -56,7 +56,7 @@ public class ModuleInfoTestCase {
     @Test
     public void testModuleAnnotations() throws IOException {
         ModuleInfo mod = indexModuleInfo();
-        Map<DotName, List<AnnotationInstance>> annotations = mod.moduleInfoClass().annotations();
+        Map<DotName, List<AnnotationInstance>> annotations = mod.moduleInfoClass().annotationsMap();
         assertEquals(2, annotations.size());
         assertEquals(1, annotations.get(DotName.createSimple(Deprecated.class.getName())).size());
         assertEquals(1, annotations.get(DotName.createSimple("test.ModuleAnnotation")).size());

--- a/src/test/java/org/jboss/jandex/test/RecordTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/RecordTestCase.java
@@ -70,7 +70,7 @@ public class RecordTestCase {
     @Test
     public void testRecordComponentHasAnnotation() {
         ClassInfo rec = index.getClassByName(DotName.createSimple("test.RecordExample"));
-        List<AnnotationInstance> componentAnnos = rec.annotations().get(DotName.createSimple("test.RecordExample$ComponentAnnotation"));
+        List<AnnotationInstance> componentAnnos = rec.annotationsMap().get(DotName.createSimple("test.RecordExample$ComponentAnnotation"));
         assertNotNull(componentAnnos);
         assertEquals(1, componentAnnos.size());
         assertEquals(AnnotationTarget.Kind.RECORD_COMPONENT, componentAnnos.get(0).target().kind());

--- a/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
@@ -189,32 +189,32 @@ public class TypeAnnotationTestCase {
     private void verifyVExampleParameterTypes(ClassInfo referenceClass, ClassInfo declaringClass) {
         MethodInfo method = declaringClass.firstMethod("bar1");
         assertNotNull(method);
-        Type type = method.parameters().get(0);
+        Type type = method.parameterTypes().get(0);
         verifyBar1(referenceClass, type);
 
         method = declaringClass.firstMethod("bar2");
         assertNotNull(method);
-        type = method.parameters().get(0);
+        type = method.parameterTypes().get(0);
         verifyBar2(referenceClass, type);
 
         method = declaringClass.firstMethod("bar3");
         assertNotNull(method);
-        type = method.parameters().get(0);
+        type = method.parameterTypes().get(0);
         verifyBar3(referenceClass, type);
 
         method = declaringClass.firstMethod("bar4");
         assertNotNull(method);
-        type = method.parameters().get(0);
+        type = method.parameterTypes().get(0);
         verifyBar4(referenceClass, type);
 
         method = declaringClass.firstMethod("bar5");
         assertNotNull(method);
-        type = method.parameters().get(0);
+        type = method.parameterTypes().get(0);
         verifyBar5(referenceClass, type);
 
         method = declaringClass.firstMethod("bar6");
         assertNotNull(method);
-        type = method.parameters().get(0);
+        type = method.parameterTypes().get(0);
         verifyBar6(referenceClass, type);
 
         // Verify receiver

--- a/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
@@ -124,10 +124,10 @@ public class TypeParameterBoundTestCase {
                 "T extends @Nullable @Untainted java.util.List & @Untainted java.io.Serializable",
                 info.typeParameters().get(0).toString());
 
-        List<AnnotationInstance> annotationInstances = info.annotations().get(DotName.createSimple("test.Nullable"));
+        List<AnnotationInstance> annotationInstances = info.annotationsMap().get(DotName.createSimple("test.Nullable"));
         Assert.assertEquals(0,  annotationInstances.get(0).target().asType().asTypeParameterBound().boundPosition());
 
-        annotationInstances = info.annotations().get(DotName.createSimple("test.Untainted"));
+        annotationInstances = info.annotationsMap().get(DotName.createSimple("test.Untainted"));
         ArrayList<Integer> list = new ArrayList<Integer>();
         for (AnnotationInstance instance : annotationInstances) {
             TypeParameterBoundTypeTarget target = instance.target().asType().asTypeParameterBound();


### PR DESCRIPTION
This commit adds the following methods:

- `ClassInfo.annotationsMap()`
  - equivalent of `ClassInfo.annotations()`
- `MethodInfo.parameterTypes()`
  - equivalent of `MethodInfo.parameters()`
- `MethodInfo.parameterType(int)`
  - equivalent of `MethodInfo.parameters().get(index)`,
    similar to `MethodInfo.parameterName(int)`
- `MethodInfo.parametersCount()`
  - equivalent of `MethodInfo.parameters().size()`

Additionally, this commit deprecates the following methods:

- `ClassInfo.annotations()`
- `MethodInfo.parameters()`

This is all done to facilitate migration from Jandex 2.4 to 3.0,
where the 2 deprecated methods have a different return type.