### PR TITLE
Add String- and Class-accepting shortcuts

### DIFF
--- a/core/src/main/java/org/jboss/jandex/AnnotationTarget.java
+++ b/core/src/main/java/org/jboss/jandex/AnnotationTarget.java
@@ -18,6 +18,7 @@
 
 package org.jboss.jandex;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 
 /**
@@ -140,6 +141,32 @@ public interface AnnotationTarget {
     boolean hasAnnotation(DotName name);
 
     /**
+     * Returns whether an annotation instance with given name is declared on this annotation target or any of its
+     * nested annotation targets.
+     *
+     * @param name name of the annotation type to look for, must not be {@code null}
+     * @return {@code true} if the annotation is present, {@code false} otherwise
+     * @since 3.0
+     * @see #annotation(DotName)
+     */
+    default boolean hasAnnotation(String name) {
+        return hasAnnotation(DotName.createSimple(name));
+    }
+
+    /**
+     * Returns whether an annotation instance of given type is declared on this annotation target or any of its
+     * nested annotation targets.
+     *
+     * @param clazz the annotation type to look for, must not be {@code null}
+     * @return {@code true} if the annotation is present, {@code false} otherwise
+     * @since 3.0
+     * @see #annotation(DotName)
+     */
+    default boolean hasAnnotation(Class<? extends Annotation> clazz) {
+        return hasAnnotation(DotName.createSimple(clazz.getName()));
+    }
+
+    /**
      * Returns the annotation instance with given name declared on this annotation target or any of its nested
      * annotation targets. The {@code target()} method of the returned annotation instance may be used to determine
      * the exact location of the annotation instance.
@@ -155,6 +182,40 @@ public interface AnnotationTarget {
     AnnotationInstance annotation(DotName name);
 
     /**
+     * Returns the annotation instance with given name declared on this annotation target or any of its nested
+     * annotation targets. The {@code target()} method of the returned annotation instance may be used to determine
+     * the exact location of the annotation instance.
+     * <p>
+     * In case an annotation with given name occurs more than once, the result of this method is not deterministic.
+     * For such situations, {@link #annotations(DotName)} is preferable.
+     *
+     * @param name name of the annotation type to look for, must not be {@code null}
+     * @return the annotation instance, or {@code null} if not found
+     * @since 3.0
+     * @see #annotations(DotName)
+     */
+    default AnnotationInstance annotation(String name) {
+        return annotation(DotName.createSimple(name));
+    }
+
+    /**
+     * Returns the annotation instance of given type declared on this annotation target or any of its nested
+     * annotation targets. The {@code target()} method of the returned annotation instance may be used to determine
+     * the exact location of the annotation instance.
+     * <p>
+     * In case an annotation with given name occurs more than once, the result of this method is not deterministic.
+     * For such situations, {@link #annotations(DotName)} is preferable.
+     *
+     * @param clazz the annotation type to look for, must not be {@code null}
+     * @return the annotation instance, or {@code null} if not found
+     * @since 3.0
+     * @see #annotations(DotName)
+     */
+    default AnnotationInstance annotation(Class<? extends Annotation> clazz) {
+        return annotation(DotName.createSimple(clazz.getName()));
+    }
+
+    /**
      * Returns the annotation instances with given name declared on this annotation target and nested annotation targets.
      * The {@code target()} method of the returned annotation instances may be used to determine the exact location
      * of the respective annotation instance.
@@ -166,6 +227,36 @@ public interface AnnotationTarget {
      * @see #annotations()
      */
     Collection<AnnotationInstance> annotations(DotName name);
+
+    /**
+     * Returns the annotation instances with given name declared on this annotation target and nested annotation targets.
+     * The {@code target()} method of the returned annotation instances may be used to determine the exact location
+     * of the respective annotation instance.
+     *
+     * @param name name of the annotation type, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.0
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     * @see #annotations()
+     */
+    default Collection<AnnotationInstance> annotations(String name) {
+        return annotations(DotName.createSimple(name));
+    }
+
+    /**
+     * Returns the annotation instances of given type declared on this annotation target and nested annotation targets.
+     * The {@code target()} method of the returned annotation instances may be used to determine the exact location
+     * of the respective annotation instance.
+     *
+     * @param clazz the annotation type, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.0
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     * @see #annotations()
+     */
+    default Collection<AnnotationInstance> annotations(Class<? extends Annotation> clazz) {
+        return annotations(DotName.createSimple(clazz.getName()));
+    }
 
     /**
      * Returns the annotation instances with given name declared on this annotation target and nested annotation targets.
@@ -186,6 +277,50 @@ public interface AnnotationTarget {
      * @see #annotations()
      */
     Collection<AnnotationInstance> annotationsWithRepeatable(DotName name, IndexView index);
+
+    /**
+     * Returns the annotation instances with given name declared on this annotation target and nested annotation targets.
+     * The {@code target()} method of the returned annotation instances may be used to determine the exact location
+     * of the respective annotation instance.
+     * <p>
+     * If the specified annotation is repeatable, the result also contains all values from the container annotation
+     * instance. In this case, the {@link AnnotationInstance#target()} returns the target of the container annotation
+     * instance.
+     *
+     * @param name name of the annotation type, must not be {@code null}
+     * @param index index used to obtain the annotation type, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @throws IllegalArgumentException if the index is {@code null}, if the index does not contain the annotation type
+     *         or if {@code name} does not identify an annotation type
+     * @since 3.0
+     * @see #annotations(DotName)
+     * @see #annotations()
+     */
+    default Collection<AnnotationInstance> annotationsWithRepeatable(String name, IndexView index) {
+        return annotationsWithRepeatable(DotName.createSimple(name), index);
+    }
+
+    /**
+     * Returns the annotation instances of given type declared on this annotation target and nested annotation targets.
+     * The {@code target()} method of the returned annotation instances may be used to determine the exact location
+     * of the respective annotation instance.
+     * <p>
+     * If the specified annotation is repeatable, the result also contains all values from the container annotation
+     * instance. In this case, the {@link AnnotationInstance#target()} returns the target of the container annotation
+     * instance.
+     *
+     * @param clazz the annotation type, must not be {@code null}
+     * @param index index used to obtain the annotation type, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @throws IllegalArgumentException if the index is {@code null}, if the index does not contain the annotation type
+     *         or if {@code name} does not identify an annotation type
+     * @since 3.0
+     * @see #annotations(DotName)
+     * @see #annotations()
+     */
+    default Collection<AnnotationInstance> annotationsWithRepeatable(Class<? extends Annotation> clazz, IndexView index) {
+        return annotationsWithRepeatable(DotName.createSimple(clazz.getName()), index);
+    }
 
     /**
      * Returns the annotation instances declared on this annotation target and nested annotation targets.
@@ -210,6 +345,34 @@ public interface AnnotationTarget {
     boolean hasDeclaredAnnotation(DotName name);
 
     /**
+     * Returns whether an annotation instance with given name is declared on this annotation target.
+     * <p>
+     * Unlike {@link #hasAnnotation(DotName)}, this method ignores annotations declared on nested annotation targets.
+     *
+     * @param name name of the annotation type to look for, must not be {@code null}
+     * @return {@code true} if the annotation is present, {@code false} otherwise
+     * @since 3.0
+     * @see #hasAnnotation(DotName)
+     */
+    default boolean hasDeclaredAnnotation(String name) {
+        return hasDeclaredAnnotation(DotName.createSimple(name));
+    }
+
+    /**
+     * Returns whether an annotation instance of given type is declared on this annotation target.
+     * <p>
+     * Unlike {@link #hasAnnotation(DotName)}, this method ignores annotations declared on nested annotation targets.
+     *
+     * @param clazz the annotation type to look for, must not be {@code null}
+     * @return {@code true} if the annotation is present, {@code false} otherwise
+     * @since 3.0
+     * @see #hasAnnotation(DotName)
+     */
+    default boolean hasDeclaredAnnotation(Class<? extends Annotation> clazz) {
+        return hasDeclaredAnnotation(DotName.createSimple(clazz.getName()));
+    }
+
+    /**
      * Returns the annotation instance with given name declared on this annotation target.
      * <p>
      * Unlike {@link #annotation(DotName)}, this method doesn't return annotations declared on nested annotation targets.
@@ -220,6 +383,34 @@ public interface AnnotationTarget {
      * @see #annotation(DotName)
      */
     AnnotationInstance declaredAnnotation(DotName name);
+
+    /**
+     * Returns the annotation instance with given name declared on this annotation target.
+     * <p>
+     * Unlike {@link #annotation(DotName)}, this method doesn't return annotations declared on nested annotation targets.
+     *
+     * @param name name of the annotation type to look for, must not be {@code null}
+     * @return the annotation instance, or {@code null} if not found
+     * @since 3.0
+     * @see #annotation(DotName)
+     */
+    default AnnotationInstance declaredAnnotation(String name) {
+        return declaredAnnotation(DotName.createSimple(name));
+    }
+
+    /**
+     * Returns the annotation instance of given type declared on this annotation target.
+     * <p>
+     * Unlike {@link #annotation(DotName)}, this method doesn't return annotations declared on nested annotation targets.
+     *
+     * @param clazz the annotation type to look for, must not be {@code null}
+     * @return the annotation instance, or {@code null} if not found
+     * @since 3.0
+     * @see #annotation(DotName)
+     */
+    default AnnotationInstance declaredAnnotation(Class<? extends Annotation> clazz) {
+        return declaredAnnotation(DotName.createSimple(clazz.getName()));
+    }
 
     /**
      * Returns the annotation instances with given name declared on this annotation target.
@@ -240,6 +431,51 @@ public interface AnnotationTarget {
      * @see #annotationsWithRepeatable(DotName, IndexView)
      */
     Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName name, IndexView index);
+
+    /**
+     * Returns the annotation instances with given name declared on this annotation target.
+     * <p>
+     * If the specified annotation is repeatable, the result also contains all values from the container annotation
+     * instance. In this case, the {@link AnnotationInstance#target()} returns the target of the container annotation
+     * instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, IndexView)}, this method doesn't return annotations
+     * declared on nested annotation targets.
+     *
+     * @param name name of the annotation type, must not be {@code null}
+     * @param index index used to obtain the annotation type, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @throws IllegalArgumentException if the index is {@code null}, if the index does not contain the annotation type
+     *         or if {@code name} does not identify an annotation type
+     * @since 3.0
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    default Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(String name, IndexView index) {
+        return declaredAnnotationsWithRepeatable(DotName.createSimple(name), index);
+    }
+
+    /**
+     * Returns the annotation instances of given type declared on this annotation target.
+     * <p>
+     * If the specified annotation is repeatable, the result also contains all values from the container annotation
+     * instance. In this case, the {@link AnnotationInstance#target()} returns the target of the container annotation
+     * instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, IndexView)}, this method doesn't return annotations
+     * declared on nested annotation targets.
+     *
+     * @param clazz the annotation type, must not be {@code null}
+     * @param index index used to obtain the annotation type, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @throws IllegalArgumentException if the index is {@code null}, if the index does not contain the annotation type
+     *         or if {@code name} does not identify an annotation type
+     * @since 3.0
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    default Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(Class<? extends Annotation> clazz,
+            IndexView index) {
+        return declaredAnnotationsWithRepeatable(DotName.createSimple(clazz.getName()), index);
+    }
 
     /**
      * Returns the annotation instances declared on this annotation target.

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -78,6 +78,20 @@ public final class DotName implements Comparable<DotName> {
     }
 
     /**
+     * Constructs a simple {@link DotName} which stores the name of given class in its entirety.
+     * This variant is ideal for temporary usage, such as looking up an entry in a {@code Map}
+     * or an {@linkplain Index index}.
+     * <p>
+     * This method is a shortcut for {@code DotName.createSimple(clazz.getName())}.
+     *
+     * @param clazz a class whose fully qualified name is returned; must not be {@code null}
+     * @return a simple {@code DotName} that wraps the name of given {@code clazz}; never {@code null}
+     */
+    public static DotName createSimple(Class<?> clazz) {
+        return createSimple(clazz.getName());
+    }
+
+    /**
      * Constructs a componentized {@link DotName}. Such {@code DotName} refers to
      * a parent prefix (or {@code null} if there is no further prefix) in addition
      * to a local name that has no dot separator. The fully qualified name this


### PR DESCRIPTION
In Jandex 3.0.0, we added shortcut methods to `IndexView` so that users
don't have to always create an instance of `DotName`. These methods
accept `String` (which is wrapped into `DotName`) and even `Class<?>`
(whose `getName()` is wrapped into `DotName`).

In this commit, we add similar shortcuts to `DotName.createSimple()`
and all annotation access methods on `AnnotationTarget`.