### PR TITLE
Fix the implementation of `TypeVariable.hashCode()`

### DIFF
--- a/core/src/main/java/org/jboss/jandex/TypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariable.java
@@ -174,6 +174,8 @@ public final class TypeVariable extends Type {
         hash = super.hashCode();
         hash = 31 * hash + name.hashCode();
         hash = 31 * hash + Arrays.hashCode(bounds);
-        return this.hash |= (hash & HASH_MASK);
+        hash &= HASH_MASK;
+        this.hash |= hash;
+        return hash;
     }
 }


### PR DESCRIPTION
Previous implementation of this method was wrong in case the type variable has an implicit bound of `Object`. To conserve memory, `TypeVariable` stores the information whether the first bound is implicitly `Object` as the most significant bit of the `hash` field, which also serves as a hash code cache.

Specifically, if the type variable has an implicit `Object` bound, the MSB is set to `1`, otherwise it is set to `0`. When it's `1`, the `hashCode()` method used to return one value when first called and a different value for subsequent calls.

This is because the beginning of `hashCode()` looks like this:

    int hash = this.hash & HASH_MASK;
    if (hash != 0) {
        return hash;
    }

When the hash code has already been computed, the method returns the stored value, properly masked to always have a `0` at the MSB. When the hash code has not been computed yet, it is computed, cached and returned. The code for caching the computed value and returning it used to look like this:

    return this.hash |= (hash & HASH_MASK);

That is partly wrong. The hash code is cached correctly, but then the whole value of `this.hash` is returned, including the non-masked MSB, which is `1` when the first bound is implicitly `Object`.

This commit splits the two operations (storing into cache and returning) so that the `hashCode()` method always returns a properly masked value:

    hash &= HASH_MASK;
    this.hash |= hash;
    return hash;