### PR TITLE
Improve how the `test-data` module is built using JDK 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
       with:
         token: ${{secrets.RELEASE_TOKEN}}
 
-    - name: Set up JDK 8
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: temurin
-        java-version: 8
+        java-version: 17
 
     - name: Maven release ${{steps.metadata.outputs.current-version}}
       run: |

--- a/core/src/test/java/org/jboss/jandex/test/BytecodeVersionTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/BytecodeVersionTest.java
@@ -1,0 +1,49 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Release builds (as well as downstream rebuilds) of Jandex are supposed to be built using JDK 17,
+ * so that the {@code test-data} module doesn't have to download a second JDK during the build process,
+ * but we want to make sure those builds still produce Java 8 bytecode.
+ */
+public class BytecodeVersionTest {
+    @Test
+    public void verifyJava8() throws IOException {
+        try (InputStream in = BytecodeVersionTest.class.getResourceAsStream("/org/jboss/jandex/Main.class")) {
+            if (in == null) {
+                fail("Could not find org.jboss.jandex.Main");
+            }
+
+            DataInputStream data = new DataInputStream(new BufferedInputStream(in));
+            verifyMagic(data);
+            verifyVersion(data);
+        }
+    }
+
+    private void verifyMagic(DataInputStream stream) throws IOException {
+        byte[] buf = new byte[4];
+
+        stream.readFully(buf);
+        if (buf[0] != (byte) 0xCA || buf[1] != (byte) 0xFE || buf[2] != (byte) 0xBA || buf[3] != (byte) 0xBE) {
+            fail("Invalid magic value: " + Arrays.toString(buf));
+        }
+    }
+
+    private void verifyVersion(DataInputStream stream) throws IOException {
+        int minor = stream.readUnsignedShort();
+        int major = stream.readUnsignedShort();
+
+        if (major != 52) { // Java 8
+            fail("Unexpected class file format version: " + major + "." + minor + ", Jandex must be Java 8 bytecode");
+        }
+    }
+}

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -36,6 +36,12 @@
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/maven-plugin/src/test/java/org/jboss/jandex/maven/BytecodeVersionTest.java
+++ b/maven-plugin/src/test/java/org/jboss/jandex/maven/BytecodeVersionTest.java
@@ -1,0 +1,49 @@
+package org.jboss.jandex.maven;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Release builds (as well as downstream rebuilds) of Jandex are supposed to be built using JDK 17,
+ * so that the {@code test-data} module doesn't have to download a second JDK during the build process,
+ * but we want to make sure those builds still produce Java 8 bytecode.
+ */
+public class BytecodeVersionTest {
+    @Test
+    public void verifyJava8() throws IOException {
+        try (InputStream in = BytecodeVersionTest.class.getResourceAsStream("/org/jboss/jandex/maven/JandexGoal.class")) {
+            if (in == null) {
+                fail("Could not find org.jboss.jandex.maven.JandexGoal");
+            }
+
+            DataInputStream data = new DataInputStream(new BufferedInputStream(in));
+            verifyMagic(data);
+            verifyVersion(data);
+        }
+    }
+
+    private void verifyMagic(DataInputStream stream) throws IOException {
+        byte[] buf = new byte[4];
+
+        stream.readFully(buf);
+        if (buf[0] != (byte) 0xCA || buf[1] != (byte) 0xFE || buf[2] != (byte) 0xBA || buf[3] != (byte) 0xBE) {
+            fail("Invalid magic value: " + Arrays.toString(buf));
+        }
+    }
+
+    private void verifyVersion(DataInputStream stream) throws IOException {
+        int minor = stream.readUnsignedShort();
+        int major = stream.readUnsignedShort();
+
+        if (major != 52) { // Java 8
+            fail("Unexpected class file format version: " + major + "." + minor + ", Jandex must be Java 8 bytecode");
+        }
+    }
+}

--- a/test-data/pom.xml
+++ b/test-data/pom.xml
@@ -21,43 +21,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>com.igormaznitsa</groupId>
-                <artifactId>mvn-jlink-wrapper</artifactId>
-                <version>${version.mvn-jlink-wrapper}</version>
-                <executions>
-                    <execution>
-                        <id>download-jdk</id>
-                        <goals>
-                            <goal>cache-jdk</goal>
-                        </goals>
-                        <configuration>
-                            <jdkCachePath>${project.basedir}/jdk-cache</jdkCachePath>
-                            <jdkPathProperty>custom-jdk-path</jdkPathProperty>
-                            <provider>ADOPT</provider>
-                            <providerConfig>
-                                <release>${java.version}</release>
-                                <arch>x64</arch> <!-- TODO select automatically, but how? -->
-                            </providerConfig>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <executable>${custom-jdk-path}/bin/javac</executable>
-                            <fork>true</fork>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- doesn't work correctly on nested records, even with the `compliance` version set -->
             <plugin>
                 <groupId>net.revelc.code</groupId>
@@ -71,57 +34,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <!-- exclude `module-info.class`, otherwise Maven JAR plugin invokes current JDK's `jar`, which may fail -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>module-info.class</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <!-- add `module-info.class` and the module attributes using custom JDK's `jar` -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${version.exec-maven-plugin}</version>
-                <executions>
-                    <execution>
-                        <id>jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${custom-jdk-path}/bin/jar</executable>
-                            <workingDirectory>${project.build.directory}</workingDirectory>
-                            <arguments>
-                                <argument>--update</argument>
-                                <argument>--file</argument>
-                                <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
-                                <argument>--main-class</argument>
-                                <argument>test.exec.Main</argument>
-                                <argument>--module-version</argument>
-                                <argument>1.0</argument>
-                                <argument>-C</argument>
-                                <argument>${project.build.outputDirectory}</argument>
-                                <argument>module-info.class</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <javadocExecutable>${custom-jdk-path}/bin/javadoc</javadocExecutable>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -138,6 +50,145 @@
             <properties>
                 <maven.compiler.parameters>true</maven.compiler.parameters>
             </properties>
+        </profile>
+
+        <profile>
+            <id>fix-module-info</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${version.exec-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${env.JAVA_HOME}/bin/jar</executable>
+                                    <workingDirectory>${project.build.directory}</workingDirectory>
+                                    <arguments>
+                                        <argument>--update</argument>
+                                        <argument>--file</argument>
+                                        <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
+                                        <argument>--main-class</argument>
+                                        <argument>test.exec.Main</argument>
+                                        <argument>--module-version</argument>
+                                        <argument>1.0</argument>
+                                        <argument>-C</argument>
+                                        <argument>${project.build.outputDirectory}</argument>
+                                        <argument>module-info.class</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>build-with-downloaded-jdk17</id>
+            <activation>
+                <jdk>(,17)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.igormaznitsa</groupId>
+                        <artifactId>mvn-jlink-wrapper</artifactId>
+                        <version>${version.mvn-jlink-wrapper}</version>
+                        <executions>
+                            <execution>
+                                <id>download-jdk</id>
+                                <goals>
+                                    <goal>cache-jdk</goal>
+                                </goals>
+                                <configuration>
+                                    <jdkCachePath>${project.basedir}/jdk-cache</jdkCachePath>
+                                    <jdkPathProperty>custom-jdk-path</jdkPathProperty>
+                                    <provider>ADOPT</provider>
+                                    <providerConfig>
+                                        <release>${java.version}</release>
+                                        <arch>x64</arch> <!-- TODO select automatically, but how? -->
+                                    </providerConfig>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <executable>${custom-jdk-path}/bin/javac</executable>
+                                    <fork>true</fork>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- exclude `module-info.class`, otherwise Maven JAR plugin invokes current JDK's `jar`, which may fail -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+
+                    <!-- add `module-info.class` and the module attributes using custom JDK's `jar` -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${version.exec-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${custom-jdk-path}/bin/jar</executable>
+                                    <workingDirectory>${project.build.directory}</workingDirectory>
+                                    <arguments>
+                                        <argument>--update</argument>
+                                        <argument>--file</argument>
+                                        <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
+                                        <argument>--main-class</argument>
+                                        <argument>test.exec.Main</argument>
+                                        <argument>--module-version</argument>
+                                        <argument>1.0</argument>
+                                        <argument>-C</argument>
+                                        <argument>${project.build.outputDirectory}</argument>
+                                        <argument>module-info.class</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <javadocExecutable>${custom-jdk-path}/bin/javadoc</javadocExecutable>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Previously, the `test-data` module was always built using a second JDK downloaded during build using a Maven plugin. This is hostile to downstream rebuilds in an air-gapped environment and makes the release process more complex and fragile for no good reason.

With this commit, a second JDK is only downloaded if the "current" JDK is older than 17. If the "current" JDK is 17+, it is used to build all modules, including `test-data`. We still want to make sure that the core Jandex library, as well as the Maven plugin, produce Java 8 bytecode. For that reason, this commit adds an automated test to both modules which verifies that the class file version of some class is `52` (Java 8).

Also, this commit changes the JDK version used for release to 17, to eat our own dog food.

Fixes #264