### PR TITLE
Use the `--release` option when compiling on JDK 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,17 @@
 
     <profiles>
         <profile>
+            <id>compiler-release-option</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <!-- setting this in a profile because the Java 8 compiler doesn't know the `release` option -->
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+
+        <profile>
             <id>release</id>
             <activation>
                 <property>


### PR DESCRIPTION
When compiling with JDK 8, we still need to use `-source` and `-target`, because JDK 8 doesn't know the `--release` option. However, with JDK 9+, it is better to use `--release`, which not only instructs the compiler to treat the source code as Java 8 and emit Java 8 bytecode, but also compiles against JDK 8 core library signatures.

This is a follow-up on #265 and is a part of the resolution of #264.