### PR TITLE
Fix class ordering when propagating type annotations

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -2448,14 +2448,18 @@ public final class Indexer {
 
             @Override
             public int compare(ClassInfo c1, ClassInfo c2) {
-                if (isEnclosedIn(c1, c2)) {
+                if (c1.name().equals(c2.name())) {
+                    return 0;
+                } else if (isEnclosedIn(c1, c2)) {
                     // c1 is enclosed in c2, so c2 must be processed sooner
                     return 1;
                 } else if (isEnclosedIn(c2, c1)) {
                     // c2 is enclosed in c1, so c1 must be processed sooner
                     return -1;
                 } else {
-                    return 0;
+                    // we really only need partial order here,
+                    // but `Comparator` must establish total order
+                    return c1.name().compareTo(c2.name());
                 }
             }
         });


### PR DESCRIPTION
To propagate type annotations across nested classes, we sort the entire set of indexed classes so that outer classes come before inner classes. We don't really care about ordering between classes that are not enclosed in one another. In other words, if we consider the equivalence relation of "be enclosed in" (where we consider a class to be enclosed in itself, so that the relation is reflexive and hence indeed equivalence), we must only sort the equivalence classes of this relation, individually. That is, we define partial order on classes.

However, to perform that sort, we use the sorting routine in the JDK, which uses the order defined by a `Comparator`, and that order must be total. In this commit, we define a total order between classes like so:

1. For each pair of classes A and B:
2. if A and B have the same name, they are considered equal;
3. if A is enclosed in B, A is considered greater than B;
4. if B is enclosed in A, A is considered less than B;
5. otherwise, A and B are sorted lexicographically based on their name.

The `Comparator` we use to sort the indexed classes implements this order.

Fixes #289