### PR TITLE
Add API for reconstructing descriptors and generic signatures

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Descriptor.java
+++ b/core/src/main/java/org/jboss/jandex/Descriptor.java
@@ -1,0 +1,57 @@
+package org.jboss.jandex;
+
+import java.util.function.Function;
+
+/**
+ * Implementations of this interface have a bytecode descriptor, as defined in JVMS 17, chapter 4.3.
+ */
+public interface Descriptor {
+    Function<String, Type> NO_SUBSTITUTION = ignored -> null;
+
+    /**
+     * Returns a bytecode descriptor of this element.
+     * <p>
+     * Note that the return value does not come directly from bytecode. Jandex does not store the descriptor
+     * strings. Instead, the return value is reconstructed from the Jandex object model.
+     *
+     * @return a bytecode descriptor of this declaration, never {@code null}
+     */
+    default String descriptor() {
+        return descriptor(NO_SUBSTITUTION);
+    }
+
+    /**
+     * Returns a bytecode descriptor of this element.
+     * <p>
+     * Descriptors of type variables are substituted for descriptors of types provided by the substitution
+     * function {@code typeVariableSubstitution}. If the substitution function returns {@code null}
+     * for some type variable identifier, or if it returns the type variable itself, no substitution happens
+     * and the type variable descriptor is used unmodified.
+     * <p>
+     * Note that the return value does not come directly from bytecode. Jandex does not store the descriptor
+     * strings. Instead, the return value is reconstructed from the Jandex object model.
+     *
+     * @param typeVariableSubstitution a substitution function from type variable identifiers to types
+     * @return a bytecode descriptor of this declaration, never {@code null}
+     */
+    String descriptor(Function<String, Type> typeVariableSubstitution);
+
+    // ---
+    // utilities for advanced use cases
+
+    /**
+     * Appends a bytecode descriptor of a single type to given {@code StringBuilder}.
+     * <p>
+     * Descriptors of type variables are substituted for descriptors of types provided by the substitution
+     * function {@code typeVariableSubstitution}. If the substitution function returns {@code null}
+     * for some type variable identifier, or if it returns the type variable itself, no substitution happens
+     * and the type variable descriptor is used unmodified.
+     *
+     * @param type a type whose bytecode descriptor is appended to {@code result}
+     * @param typeVariableSubstitution a substitution function from type variable identifiers to types
+     * @param result the {@code StringBuilder} to which the bytecode descriptor is appended
+     */
+    static void forType(Type type, Function<String, Type> typeVariableSubstitution, StringBuilder result) {
+        DescriptorReconstruction.typeDescriptor(type, typeVariableSubstitution, result);
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/DescriptorReconstruction.java
+++ b/core/src/main/java/org/jboss/jandex/DescriptorReconstruction.java
@@ -1,0 +1,112 @@
+package org.jboss.jandex;
+
+import java.util.function.Function;
+
+final class DescriptorReconstruction {
+    static String fieldDescriptor(FieldInfo field, Function<String, Type> typeVariableSubstitution) {
+        FieldInternal internal = field.fieldInternal();
+
+        StringBuilder result = new StringBuilder();
+        typeDescriptor(internal.type(), typeVariableSubstitution, result);
+        return result.toString();
+    }
+
+    static String methodDescriptor(MethodInfo method, Function<String, Type> typeVariableSubstitution) {
+        MethodInternal internal = method.methodInternal();
+
+        StringBuilder result = new StringBuilder();
+        result.append('(');
+        for (Type parameterType : internal.parameterTypesArray()) {
+            typeDescriptor(parameterType, typeVariableSubstitution, result);
+        }
+        result.append(')');
+        typeDescriptor(internal.returnType(), typeVariableSubstitution, result);
+        return result.toString();
+    }
+
+    static String recordComponentDescriptor(RecordComponentInfo recordComponent,
+            Function<String, Type> typeVariableSubstitution) {
+        RecordComponentInternal internal = recordComponent.recordComponentInternal();
+
+        StringBuilder result = new StringBuilder();
+        typeDescriptor(internal.type(), typeVariableSubstitution, result);
+        return result.toString();
+    }
+
+    static void typeDescriptor(Type type, Function<String, Type> substitution, StringBuilder result) {
+        switch (type.kind()) {
+            case VOID:
+                result.append('V');
+                break;
+            case PRIMITIVE:
+                PrimitiveType.Primitive primitive = type.asPrimitiveType().primitive();
+                switch (primitive) {
+                    case BOOLEAN:
+                        result.append('Z');
+                        return;
+                    case BYTE:
+                        result.append('B');
+                        return;
+                    case SHORT:
+                        result.append('S');
+                        return;
+                    case INT:
+                        result.append('I');
+                        return;
+                    case LONG:
+                        result.append('J');
+                        return;
+                    case FLOAT:
+                        result.append('F');
+                        return;
+                    case DOUBLE:
+                        result.append('D');
+                        return;
+                    case CHAR:
+                        result.append('C');
+                        return;
+                    default:
+                        throw new IllegalArgumentException("unkown primitive type " + primitive);
+                }
+            case ARRAY:
+                ArrayType arrayType = type.asArrayType();
+                for (int i = 0; i < arrayType.dimensions(); i++) {
+                    result.append('[');
+                }
+                typeDescriptor(arrayType.component(), substitution, result);
+                break;
+            case CLASS:
+            case PARAMETERIZED_TYPE:
+            case WILDCARD_TYPE:
+                objectTypeDescriptor(type.name(), result);
+                break;
+            case TYPE_VARIABLE:
+                typeVariableDescriptor(type, type.asTypeVariable().identifier(), substitution, result);
+                break;
+            case UNRESOLVED_TYPE_VARIABLE:
+                typeVariableDescriptor(type, type.asUnresolvedTypeVariable().identifier(), substitution, result);
+                break;
+            case TYPE_VARIABLE_REFERENCE:
+                typeVariableDescriptor(type, type.asTypeVariableReference().identifier(), substitution, result);
+                break;
+            default:
+                throw new IllegalArgumentException("unknown type " + type);
+        }
+    }
+
+    static void objectTypeDescriptor(DotName name, StringBuilder result) {
+        result.append('L').append(name.toString('/')).append(';');
+    }
+
+    // `typeVariable` is always the type variable whose identifier is `typeVariableIdentifier`; its purpose is
+    // to prevent possible cycle when `substitution.apply(typeVariableIdentifier)` returns `typeVariable`
+    private static void typeVariableDescriptor(Type typeVariable, String typeVariableIdentifier,
+            Function<String, Type> substitution, StringBuilder result) {
+        Type type = substitution == null ? null : substitution.apply(typeVariableIdentifier);
+        if (type == null || type == typeVariable) {
+            objectTypeDescriptor(typeVariable.name(), result);
+        } else {
+            typeDescriptor(type, substitution, result);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -275,23 +275,29 @@ public final class DotName implements Comparable<DotName> {
     }
 
     /**
-     * Returns the regular fully qualifier class name.
+     * Returns the regular binary class name.
      *
-     * @return The fully qualified class name
+     * @return the binary class name
      */
     public String toString() {
         return toString('.');
     }
 
+    /**
+     * Returns the regular binary class name where {@code delim} is used as a package separator.
+     *
+     * @param delim the package separator; typically {@code .}, but may be e.g. {@code /}
+     *        to construct a bytecode descriptor
+     * @return the binary class name with given character used as a package separator
+     */
     public String toString(char delim) {
-        String string = local;
-        if (prefix != null) {
+        if (componentized) {
             StringBuilder builder = new StringBuilder();
             buildString(delim, builder);
-            string = builder.toString();
+            return builder.toString();
+        } else {
+            return delim == '.' ? local : local.replace('.', delim);
         }
-
-        return string;
     }
 
     private void buildString(char delim, StringBuilder builder) {

--- a/core/src/main/java/org/jboss/jandex/GenericSignature.java
+++ b/core/src/main/java/org/jboss/jandex/GenericSignature.java
@@ -1,0 +1,110 @@
+package org.jboss.jandex;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Implementations of this interface have a generic signature, as defined in JVMS 17, chapter 4.7.9.1.
+ */
+public interface GenericSignature {
+    Function<String, Type> NO_SUBSTITUTION = ignored -> null;
+
+    /**
+     * Returns whether this declaration must have a generic signature. That is, whether the Java compiler
+     * when compiling this declaration had to emit the {@code Signature} bytecode attribute.
+     *
+     * @return whether this declaration must have a generic signature
+     */
+    boolean requiresGenericSignature();
+
+    /**
+     * Returns a generic signature of this declaration, possibly without any generic-related information.
+     * That is, produces a correct generic signature even if this declaration is not generic
+     * and does not use any type variables.
+     * <p>
+     * Note that the return value does not come directly from bytecode. Jandex does not store the signature
+     * strings. Instead, the return value is reconstructed from the Jandex object model.
+     *
+     * @return a generic signature of this declaration, never {@code null}
+     */
+    default String genericSignature() {
+        return genericSignature(NO_SUBSTITUTION);
+    }
+
+    /**
+     * Returns a generic signature of this declaration, possibly without any generic-related information.
+     * That is, produces a correct generic signature even if this declaration is not generic
+     * and does not use any type variables.
+     * <p>
+     * Signatures of type variables are substituted for signatures of types provided by the substitution
+     * function {@code typeVariableSubstitution}. If the substitution function returns {@code null}
+     * for some type variable identifier, or if it returns the type variable itself, no substitution happens
+     * and the type variable signature is used unmodified.
+     * <p>
+     * Note that the return value does not come directly from bytecode. Jandex does not store the signature
+     * strings. Instead, the return value is reconstructed from the Jandex object model.
+     *
+     * @param typeVariableSubstitution a substitution function from type variable identifiers to types
+     * @return a generic signature of this declaration with type variables substituted, never {@code null}
+     */
+    String genericSignature(Function<String, Type> typeVariableSubstitution);
+
+    /**
+     * Returns a {@linkplain #genericSignature() generic signature} of this declaration
+     * if {@linkplain #requiresGenericSignature() required}.
+     *
+     * @return a generic signature of this declaration, or {@code null} if this declaration doesn't have to have one
+     */
+    default String genericSignatureIfRequired() {
+        return genericSignatureIfRequired(NO_SUBSTITUTION);
+    }
+
+    /**
+     * Returns a {@linkplain #genericSignature(Function) generic signature} of this declaration
+     * if {@linkplain #requiresGenericSignature() required}. Type variable signatures are substituted.
+     *
+     * @param typeVariableSubstitution a substitution function from type variable identifiers to types
+     * @return a generic signature of this declaration with type variables substituted, or {@code null}
+     *         if this declaration does not have to have one
+     */
+    default String genericSignatureIfRequired(Function<String, Type> typeVariableSubstitution) {
+        return requiresGenericSignature() ? genericSignature(typeVariableSubstitution) : null;
+    }
+
+    // ---
+    // utilities for advanced use cases
+
+    /**
+     * Appends a generic signature of a type parameter list, including the {@code <} at the beginning and
+     * {@code >} at the end, to given {@code StringBuilder}.
+     * <p>
+     * Signatures of type variables are substituted for signatures of types provided by the substitution
+     * function {@code typeVariableSubstitution}. If the substitution function returns {@code null}
+     * for some type variable identifier, or if it returns the type variable itself, no substitution happens
+     * and the type variable signature is used unmodified.
+     *
+     * @param typeParameters a list of type parameters whose generic signature is appended to {@code result}
+     * @param typeVariableSubstitution a substitution function from type variable identifiers to types
+     * @param result the {@code StringBuilder} to which the generic signature is appended
+     */
+    static void forTypeParameters(List<TypeVariable> typeParameters, Function<String, Type> typeVariableSubstitution,
+            StringBuilder result) {
+        GenericSignatureReconstruction.typeParametersSignature(typeParameters, typeVariableSubstitution, result);
+    }
+
+    /**
+     * Appends a generic signature of a single type to given {@code StringBuilder}.
+     * <p>
+     * Signatures of type variables are substituted for signatures of types provided by the substitution
+     * function {@code typeVariableSubstitution}. If the substitution function returns {@code null}
+     * for some type variable identifier, or if it returns the type variable itself, no substitution happens
+     * and the type variable signature is used unmodified.
+     *
+     * @param type a type parameters whose generic signature is appended to {@code result}
+     * @param typeVariableSubstitution a substitution function from type variable identifiers to types
+     * @param result the {@code StringBuilder} to which the generic signature is appended
+     */
+    static void forType(Type type, Function<String, Type> typeVariableSubstitution, StringBuilder result) {
+        GenericSignatureReconstruction.typeSignature(type, typeVariableSubstitution, result);
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/GenericSignatureReconstruction.java
+++ b/core/src/main/java/org/jboss/jandex/GenericSignatureReconstruction.java
@@ -1,0 +1,312 @@
+package org.jboss.jandex;
+
+import java.util.List;
+import java.util.function.Function;
+
+final class GenericSignatureReconstruction {
+    static boolean requiresGenericSignature(ClassInfo clazz) {
+        // JVMS 17, chapter 4.7.9.1. Signatures:
+        //
+        // Java compiler must emit ...
+        //
+        // A class signature for any class or interface declaration which is either generic,
+        // or has a parameterized type as a superclass or superinterface, or both.
+
+        if (!clazz.typeParameters().isEmpty()) {
+            return true;
+        }
+
+        {
+            Type superType = clazz.superClassType();
+            if (superType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+                return true;
+            }
+        }
+
+        for (Type superType : clazz.interfaceTypes()) {
+            if (superType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static boolean requiresGenericSignature(MethodInfo method) {
+        // JVMS 17, chapter 4.7.9.1. Signatures:
+        //
+        // Java compiler must emit ...
+        //
+        // A method signature for any method or constructor declaration which is either generic,
+        // or has a type variable or parameterized type as the return type or a formal parameter type,
+        // or has a type variable in a throws clause, or any combination thereof.
+        //
+        // If the throws clause of a method or constructor declaration does not involve type variables,
+        // then a compiler may treat the declaration as having no throws clause for the purpose of
+        // emitting a method signature.
+
+        if (!method.typeParameters().isEmpty()) {
+            return true;
+        }
+
+        {
+            if (requiresGenericSignature(method.returnType())) {
+                return true;
+            }
+        }
+
+        for (Type parameterType : method.parameterTypes()) {
+            if (requiresGenericSignature(parameterType)) {
+                return true;
+            }
+        }
+
+        if (hasThrowsSignature(method)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    static boolean requiresGenericSignature(FieldInfo field) {
+        // JVMS 17, chapter 4.7.9.1. Signatures:
+        //
+        // Java compiler must emit ...
+        //
+        // A field signature for any field, formal parameter, local variable, or record component
+        // declaration whose type uses a type variable or a parameterized type.
+
+        return requiresGenericSignature(field.type());
+    }
+
+    static boolean requiresGenericSignature(RecordComponentInfo recordComponent) {
+        // JVMS 17, chapter 4.7.9.1. Signatures:
+        //
+        // Java compiler must emit ...
+        //
+        // A field signature for any field, formal parameter, local variable, or record component
+        // declaration whose type uses a type variable or a parameterized type.
+
+        return requiresGenericSignature(recordComponent.type());
+    }
+
+    private static boolean requiresGenericSignature(Type type) {
+        return type.kind() == Type.Kind.TYPE_VARIABLE
+                || type.kind() == Type.Kind.UNRESOLVED_TYPE_VARIABLE
+                || type.kind() == Type.Kind.PARAMETERIZED_TYPE;
+    }
+
+    // ---
+    // for grammar, see JVMS 17, chapter 4.7.9.1. Signatures
+
+    static String reconstructGenericSignature(ClassInfo clazz, Function<String, Type> typeVariableSubstitution) {
+        StringBuilder result = new StringBuilder();
+
+        if (!clazz.typeParameters().isEmpty()) {
+            typeParametersSignature(clazz.typeParameters(), typeVariableSubstitution, result);
+        }
+
+        typeSignature(clazz.superClassType(), typeVariableSubstitution, result);
+
+        for (Type interfaceType : clazz.interfaceTypes()) {
+            typeSignature(interfaceType, typeVariableSubstitution, result);
+        }
+
+        return result.toString();
+    }
+
+    static String reconstructGenericSignature(MethodInfo method, Function<String, Type> typeVariableSubstitution) {
+        StringBuilder result = new StringBuilder();
+
+        if (!method.typeParameters().isEmpty()) {
+            typeParametersSignature(method.typeParameters(), typeVariableSubstitution, result);
+        }
+
+        result.append('(');
+        for (Type parameter : method.parameterTypes()) {
+            typeSignature(parameter, typeVariableSubstitution, result);
+        }
+        result.append(')');
+
+        typeSignature(method.returnType(), typeVariableSubstitution, result);
+
+        if (hasThrowsSignature(method)) {
+            for (Type exception : method.exceptions()) {
+                result.append('^');
+                typeSignature(exception, typeVariableSubstitution, result);
+            }
+        }
+
+        return result.toString();
+    }
+
+    static String reconstructGenericSignature(FieldInfo field, Function<String, Type> typeVariableSubstitution) {
+        StringBuilder result = new StringBuilder();
+
+        typeSignature(field.type(), typeVariableSubstitution, result);
+
+        return result.toString();
+    }
+
+    static String reconstructGenericSignature(RecordComponentInfo recordComponent,
+            Function<String, Type> typeVariableSubstitution) {
+        StringBuilder result = new StringBuilder();
+
+        typeSignature(recordComponent.type(), typeVariableSubstitution, result);
+
+        return result.toString();
+    }
+
+    private static boolean hasThrowsSignature(MethodInfo method) {
+        // JVMS 17, chapter 4.7.9.1. Signatures:
+        //
+        // If the throws clause of a method or constructor declaration does not involve type variables,
+        // then a compiler may treat the declaration as having no throws clause for the purpose of
+        // emitting a method signature.
+
+        // also, no need to check if an exception type is of kind PARAMETERIZED_TYPE, because
+        //
+        // JLS 17, chapter 8.1.2. Generic Classes and Type Parameters:
+        //
+        // It is a compile-time error if a generic class is a direct or indirect subclass of Throwable.
+
+        for (Type type : method.exceptions()) {
+            if (type.kind() == Type.Kind.TYPE_VARIABLE
+                    || type.kind() == Type.Kind.UNRESOLVED_TYPE_VARIABLE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void typeParametersSignature(List<TypeVariable> typeParameters,
+            Function<String, Type> substitution, StringBuilder result) {
+
+        if (typeParameters.isEmpty()) {
+            return;
+        }
+
+        // it is not clear whether we should substitute type variables in type parameter bounds;
+        // we currently do, because the Quarkus original (where this is adapted from) also did
+
+        result.append('<');
+        for (TypeVariable typeParameter : typeParameters) {
+            result.append(typeParameter.identifier());
+
+            if (typeParameter.hasImplicitObjectBound()) {
+                result.append(':');
+            }
+            for (Type bound : typeParameter.bounds()) {
+                result.append(':');
+                typeSignature(bound, substitution, result);
+            }
+        }
+        result.append('>');
+    }
+
+    static void typeSignature(Type type, Function<String, Type> substitution, StringBuilder result) {
+        switch (type.kind()) {
+            case VOID:
+                result.append('V');
+                break;
+            case PRIMITIVE:
+                PrimitiveType.Primitive primitive = type.asPrimitiveType().primitive();
+                switch (primitive) {
+                    case BOOLEAN:
+                        result.append('Z');
+                        return;
+                    case CHAR:
+                        result.append('C');
+                        return;
+                    case BYTE:
+                        result.append('B');
+                        return;
+                    case SHORT:
+                        result.append('S');
+                        return;
+                    case INT:
+                        result.append('I');
+                        return;
+                    case LONG:
+                        result.append('J');
+                        return;
+                    case FLOAT:
+                        result.append('F');
+                        return;
+                    case DOUBLE:
+                        result.append('D');
+                        return;
+                    default:
+                        throw new IllegalArgumentException("unkown primitive type " + primitive);
+                }
+            case CLASS:
+                ClassType classType = type.asClassType();
+                result.append('L').append(classType.name().toString('/')).append(';');
+                break;
+            case ARRAY:
+                ArrayType arrayType = type.asArrayType();
+                for (int i = 0; i < arrayType.dimensions(); i++) {
+                    result.append('[');
+                }
+                typeSignature(arrayType.component(), substitution, result);
+                break;
+            case PARAMETERIZED_TYPE:
+                ParameterizedType parameterizedType = type.asParameterizedType();
+                Type owner = parameterizedType.owner();
+                if (owner != null && owner.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+                    typeSignature(owner, substitution, result);
+                    // the typeSignature call on previous line always takes the PARAMETERIZED_TYPE branch,
+                    // so at this point, result ends with a ';', which we just replace with '.'
+                    assert result.charAt(result.length() - 1) == ';';
+                    result.setCharAt(result.length() - 1, '.');
+                    result.append(parameterizedType.name().local());
+                } else {
+                    result.append('L').append(parameterizedType.name().toString('/'));
+                }
+                if (!parameterizedType.arguments().isEmpty()) {
+                    result.append('<');
+                    for (Type argument : parameterizedType.arguments()) {
+                        typeSignature(argument, substitution, result);
+                    }
+                    result.append('>');
+                }
+                result.append(';');
+                break;
+            case TYPE_VARIABLE:
+                typeVariableSignature(type, type.asTypeVariable().identifier(), substitution, result);
+                break;
+            case UNRESOLVED_TYPE_VARIABLE:
+                typeVariableSignature(type, type.asUnresolvedTypeVariable().identifier(), substitution, result);
+                break;
+            case TYPE_VARIABLE_REFERENCE:
+                typeVariableSignature(type, type.asTypeVariableReference().identifier(), substitution, result);
+                break;
+            case WILDCARD_TYPE:
+                WildcardType wildcardType = type.asWildcardType();
+                if (wildcardType.superBound() != null) {
+                    result.append('-');
+                    typeSignature(wildcardType.superBound(), substitution, result);
+                } else if (ClassType.OBJECT_TYPE.equals(wildcardType.extendsBound())) {
+                    result.append('*');
+                } else {
+                    result.append('+');
+                    typeSignature(wildcardType.extendsBound(), substitution, result);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("unknown type " + type);
+        }
+    }
+
+    // `typeVariable` is always the type variable whose identifier is `typeVariableIdentifier`; its purpose is
+    // to prevent possible cycle when `substitution.apply(typeVariableIdentifier)` returns `typeVariable`
+    private static void typeVariableSignature(Type typeVariable, String typeVariableIdentifier,
+            Function<String, Type> substitution, StringBuilder result) {
+        Type type = substitution == null ? null : substitution.apply(typeVariableIdentifier);
+        if (type == null || type == typeVariable) {
+            result.append('T').append(typeVariableIdentifier).append(';');
+        } else {
+            typeSignature(type, substitution, result);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/ParameterizedType.java
+++ b/core/src/main/java/org/jboss/jandex/ParameterizedType.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /**
  * Represents a parameterized type. The {@code name()} corresponds to the raw type, and the
- * {@code arguments()} list corresponds to the type arguments passed to the generic type
+ * {@code arguments()} list corresponds to the type arguments applied to the generic class
  * in order to instantiate this parameterized type.
  * <p>
  * For example, the parameterized type {@code Map<String, Integer>} would have a name of

--- a/core/src/test/java/org/jboss/jandex/test/DescriptorReconstructionTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/DescriptorReconstructionTest.java
@@ -1,0 +1,131 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.Descriptor;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class DescriptorReconstructionTest {
+    static class TestData<A, B extends Number, C extends B, D extends C, E extends Comparable<E>> {
+        boolean booleanField;
+        int intField;
+        double doubleField;
+        String stringField;
+        List<String> listField;
+        Map<String, List<String>> mapField;
+        A typeVarWithoutBoundField;
+        B typeVarWithBoundField;
+        D typeVarWithTransitiveBoundField;
+        E recursiveTypeVarField;
+
+        void voidMethod(boolean booleanParam, List<String> listParam) {
+        }
+
+        String stringMethod(int intParam, Map<String, List<String>> mapParam, A typeVarParam) {
+            return null;
+        }
+
+        B typeVarMethod(double doubleParam, C typeVarParam, List<? extends Number> wildcardParam) {
+            return null;
+        }
+
+        <X> X genericMethodWithoutBound(X typeParamParam, D typeVarParam, List<? super Integer> wildcardParam) {
+            return null;
+        }
+
+        <X extends Number> X genericMethodWithBound(X typeParamParam, List<? super C> wildcardParam) {
+            return null;
+        }
+    }
+
+    private static IndexView index;
+
+    @BeforeAll
+    public static void setUp() throws IOException {
+        index = Index.of(TestData.class);
+    }
+
+    @Test
+    public void test() {
+        assertEquals("Lorg/jboss/jandex/test/DescriptorReconstructionTest$TestData;",
+                index.getClassByName(TestData.class).descriptor());
+
+        assertFieldDescriptor("booleanField", "Z");
+        assertFieldDescriptor("intField", "I");
+        assertFieldDescriptor("doubleField", "D");
+        assertFieldDescriptor("stringField", "Ljava/lang/String;");
+        assertFieldDescriptor("listField", "Ljava/util/List;");
+        assertFieldDescriptor("mapField", "Ljava/util/Map;");
+        assertFieldDescriptor("typeVarWithoutBoundField", "Ljava/lang/Object;");
+        assertFieldDescriptor("typeVarWithBoundField", "Ljava/lang/Number;");
+        assertFieldDescriptor("typeVarWithTransitiveBoundField", "Ljava/lang/Number;");
+        assertFieldDescriptor("recursiveTypeVarField", "Ljava/lang/Comparable;");
+
+        assertMethodDescriptor("voidMethod",
+                "(ZLjava/util/List;)V");
+        assertMethodDescriptor("stringMethod",
+                "(ILjava/util/Map;Ljava/lang/Object;)Ljava/lang/String;");
+        assertMethodDescriptor("typeVarMethod",
+                "(DLjava/lang/Number;Ljava/util/List;)Ljava/lang/Number;");
+        assertMethodDescriptor("genericMethodWithoutBound",
+                "(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;)Ljava/lang/Object;");
+        assertMethodDescriptor("genericMethodWithBound",
+                "(Ljava/lang/Number;Ljava/util/List;)Ljava/lang/Number;");
+    }
+
+    @Test
+    public void withSubstitution() {
+        assertFieldDescriptor("typeVarWithoutBoundField", "Ljava/lang/String;",
+                id -> "A".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertFieldDescriptor("typeVarWithBoundField", "Ljava/lang/String;",
+                id -> "B".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertFieldDescriptor("typeVarWithTransitiveBoundField", "Ljava/lang/Number;",
+                id -> null);
+        assertFieldDescriptor("recursiveTypeVarField", "Ljava/lang/Comparable;",
+                id -> null);
+
+        assertMethodDescriptor("typeVarMethod",
+                "(DLjava/lang/String;Ljava/util/List;)Ljava/lang/String;",
+                id -> "B".equals(id) || "C".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertMethodDescriptor("genericMethodWithoutBound",
+                "(Ljava/lang/String;Ljava/lang/Number;Ljava/util/List;)Ljava/lang/String;",
+                id -> "X".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertMethodDescriptor("genericMethodWithBound",
+                "(Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;",
+                id -> "X".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+    }
+
+    private static void assertFieldDescriptor(String name, String expectedDescriptor) {
+        assertFieldDescriptor(name, expectedDescriptor, Descriptor.NO_SUBSTITUTION);
+    }
+
+    private static void assertFieldDescriptor(String name, String expectedDescriptor, Function<String, Type> subst) {
+        ClassInfo clazz = index.getClassByName(TestData.class);
+        FieldInfo field = clazz.field(name);
+        assertEquals(expectedDescriptor, field.descriptor(subst));
+    }
+
+    private static void assertMethodDescriptor(String name, String expectedDescriptor) {
+        assertMethodDescriptor(name, expectedDescriptor, Descriptor.NO_SUBSTITUTION);
+    }
+
+    private static void assertMethodDescriptor(String name, String expectedDescriptor, Function<String, Type> subst) {
+        ClassInfo clazz = index.getClassByName(TestData.class);
+        MethodInfo method = clazz.firstMethod(name);
+        assertEquals(expectedDescriptor, method.descriptor(subst));
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
@@ -210,6 +210,19 @@ public class DotNameTestCase {
     }
 
     @Test
+    public void testToStringDelim() {
+        DotName foo = DotName.createComponentized(DotName.createComponentized(null, "root"), "thefoo");
+        foo = DotName.createComponentized(foo, "Foo");
+        assertEquals("root/thefoo/Foo", foo.toString('/'));
+        DotName inner = DotName.createComponentized(foo, "Inner", true);
+        DotName inner2 = DotName.createComponentized(inner, "Inner2", true);
+        assertEquals("root/thefoo/Foo$Inner$Inner2", inner2.toString('/'));
+
+        assertEquals("foo/bar/baz/Foo", DotName.createSimple("foo.bar.baz.Foo").toString('/'));
+        assertEquals("foo/bar/baz/Foo$Inner$Inner2", DotName.createSimple("foo.bar.baz.Foo$Inner$Inner2").toString('/'));
+    }
+
+    @Test
     public void testForNaturalComparator() {
         DotsContainer c = new DotsContainer();
         while (c.size() < 200) {
@@ -328,6 +341,7 @@ public class DotNameTestCase {
         assertNotNull(index.getClassByName(testNameSimple));
         assertNotNull(index.getClassByName(testName));
         assertEquals("$delimiters$.test.$SurroundedByDelimiters$", indexedName.toString());
+        assertEquals("$delimiters$/test/$SurroundedByDelimiters$", indexedName.toString('/'));
     }
 
     @Test

--- a/core/src/test/java/org/jboss/jandex/test/GenericSignatureReconstructionTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/GenericSignatureReconstructionTest.java
@@ -1,0 +1,437 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.GenericSignature;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.test.data.ClassInheritance;
+import org.jboss.jandex.test.data.OuterParam;
+import org.jboss.jandex.test.data.OuterParamBound;
+import org.jboss.jandex.test.data.OuterRaw;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class GenericSignatureReconstructionTest {
+    private static IndexView index;
+
+    @BeforeAll
+    public static void setUp() {
+        try {
+            index = Index.of(
+                    OuterRaw.class,
+                    OuterRaw.InnerRaw.class, OuterRaw.InnerParam.class, OuterRaw.InnerParamBound.class,
+                    OuterRaw.NestedRaw.class, OuterRaw.NestedParam.class, OuterRaw.NestedParamBound.class,
+                    OuterParam.class,
+                    OuterParam.InnerRaw.class, OuterParam.InnerParam.class, OuterParam.InnerParamBound.class,
+                    OuterParam.NestedRaw.class, OuterParam.NestedParam.class, OuterParam.NestedParamBound.class,
+                    OuterParamBound.class,
+                    OuterParamBound.InnerRaw.class, OuterParamBound.InnerParam.class, OuterParamBound.InnerParamBound.class,
+                    OuterParamBound.NestedRaw.class, OuterParamBound.NestedParam.class, OuterParamBound.NestedParamBound.class,
+                    ClassInheritance.class,
+                    ClassInheritance.PlainClass.class,
+                    ClassInheritance.ParamClass.class,
+                    ClassInheritance.ParamBoundClass.class,
+                    ClassInheritance.PlainInterface.class,
+                    ClassInheritance.ParamInterface.class,
+                    ClassInheritance.ParamBoundInterface.class,
+                    ClassInheritance.PlainClassExtendsPlainClass.class,
+                    ClassInheritance.PlainClassExtendsParamClass.class,
+                    ClassInheritance.PlainClassExtendsParamBoundClass.class,
+                    ClassInheritance.ParamClassExtendsPlainClass.class,
+                    ClassInheritance.ParamClassExtendsParamClass1.class,
+                    ClassInheritance.ParamClassExtendsParamClass2.class,
+                    ClassInheritance.ParamClassExtendsParamBoundClass.class,
+                    ClassInheritance.ParamBoundClassExtendsPlainClass.class,
+                    ClassInheritance.ParamBoundClassExtendsParamClass1.class,
+                    ClassInheritance.ParamBoundClassExtendsParamClass2.class,
+                    ClassInheritance.ParamBoundClassExtendsParamBoundClass1.class,
+                    ClassInheritance.ParamBoundClassExtendsParamBoundClass2.class,
+                    ClassInheritance.PlainClassImplementsPlainInterface.class,
+                    ClassInheritance.PlainClassImplementsParamInterface.class,
+                    ClassInheritance.PlainClassImplementsParamBoundInterface.class,
+                    ClassInheritance.ParamClassImplementsPlainInterface.class,
+                    ClassInheritance.ParamClassImplementsParamInterface1.class,
+                    ClassInheritance.ParamClassImplementsParamInterface2.class,
+                    ClassInheritance.ParamClassImplementsParamBoundInterface.class,
+                    ClassInheritance.ParamBoundClassImplementsPlainInterface.class,
+                    ClassInheritance.ParamBoundClassImplementsParamInterface1.class,
+                    ClassInheritance.ParamBoundClassImplementsParamInterface2.class,
+                    ClassInheritance.ParamBoundClassImplementsParamBoundInterface1.class,
+                    ClassInheritance.ParamBoundClassImplementsParamBoundInterface2.class,
+                    ClassInheritance.PlainClassExtendsPlainClassImplementsPlainInterface.class,
+                    ClassInheritance.PlainClassExtendsParamClassImplementsParamInterface.class,
+                    ClassInheritance.PlainClassExtendsParamBoundClassImplementsParamBoundInterface.class,
+                    ClassInheritance.ParamClassExtendsPlainClassImplementsPlainInterface.class,
+                    ClassInheritance.ParamClassExtendsParamClassImplementsParamInterface1.class,
+                    ClassInheritance.ParamClassExtendsParamClassImplementsParamInterface2.class,
+                    ClassInheritance.ParamClassExtendsParamBoundClassImplementsParamBoundInterface.class,
+                    ClassInheritance.ParamBoundClassExtendsPlainClassImplementsPlainInterface.class,
+                    ClassInheritance.ParamBoundClassExtendsParamClassImplementsParamInterface1.class,
+                    ClassInheritance.ParamBoundClassExtendsParamClassImplementsParamInterface2.class,
+                    ClassInheritance.ParamBoundClassExtendsParamBoundClassImplementsParamBoundInterface1.class,
+                    ClassInheritance.ParamBoundClassExtendsParamBoundClassImplementsParamBoundInterface2.class,
+                    ClassInheritance.OuterParam.class,
+                    ClassInheritance.OuterParam.NestedParam.class,
+                    ClassInheritance.OuterParam.InnerParam.class,
+                    ClassInheritance.OuterParam.InnerParam.InnerInnerRaw.class,
+                    ClassInheritance.OuterParam.InnerParam.InnerInnerRaw.InnerInnerInnerParam.class,
+                    ClassInheritance.OuterParam.InnerParam.InnerInnerRaw.InnerInnerInnerParam.Test.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // expected signatures here were obtained from classes compiled with OpenJDK 11.0.17
+    // and then dumped using `javap -v`
+
+    @Test
+    public void outerRaw() {
+        assertClassSignature(OuterRaw.class,
+                null);
+        assertClassSignature(OuterRaw.NestedRaw.class,
+                null);
+        assertClassSignature(OuterRaw.NestedParam.class,
+                "<X:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterRaw.NestedParamBound.class,
+                "<X:Ljava/lang/Number;:Ljava/lang/Comparable<TX;>;>Ljava/lang/Object;");
+        assertClassSignature(OuterRaw.InnerRaw.class,
+                null);
+        assertClassSignature(OuterRaw.InnerParam.class,
+                "<X:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterRaw.InnerParamBound.class,
+                "<X:Ljava/lang/Number;:Ljava/lang/Comparable<TX;>;>Ljava/lang/Object;");
+
+        assertMethodSignature(OuterRaw.class, "methodA",
+                null);
+        assertMethodSignature(OuterRaw.class, "methodB",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(TU;Lorg/jboss/jandex/test/data/OuterRaw;)TT;");
+        assertMethodSignature(OuterRaw.NestedRaw.class, "methodC",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;Lorg/jboss/jandex/test/data/OuterRaw$NestedRaw;)TT;^Ljava/lang/IllegalArgumentException;^TV;");
+        assertMethodSignature(OuterRaw.NestedParam.class, "methodD",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<-TU;>;TX;Lorg/jboss/jandex/test/data/OuterRaw$NestedParam<TX;>;)TT;");
+        assertMethodSignature(OuterRaw.NestedParamBound.class, "methodE",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<*>;TX;Lorg/jboss/jandex/test/data/OuterRaw$NestedParamBound<TX;>;)TT;^TV;");
+        assertMethodSignature(OuterRaw.InnerRaw.class, "methodF",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;Lorg/jboss/jandex/test/data/OuterRaw$InnerRaw;)TT;^Ljava/lang/IllegalArgumentException;^TV;");
+        assertMethodSignature(OuterRaw.InnerParam.class, "methodG",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<-TU;>;TX;Lorg/jboss/jandex/test/data/OuterRaw$InnerParam<TX;>;)TT;");
+        assertMethodSignature(OuterRaw.InnerParamBound.class, "methodH",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<*>;TX;Lorg/jboss/jandex/test/data/OuterRaw$InnerParamBound<TX;>;)TT;^TV;");
+
+        assertFieldSignature(OuterRaw.class, "fieldA",
+                null);
+        assertFieldSignature(OuterRaw.class, "fieldB",
+                "Ljava/util/List<Ljava/lang/String;>;");
+        assertFieldSignature(OuterRaw.class, "fieldC",
+                "Ljava/util/List<*>;");
+        assertFieldSignature(OuterRaw.class, "fieldD",
+                "Ljava/util/List<+Ljava/lang/CharSequence;>;");
+        assertFieldSignature(OuterRaw.class, "fieldE",
+                "Ljava/util/List<-Ljava/lang/String;>;");
+        assertFieldSignature(OuterRaw.NestedParam.class, "fieldF",
+                "TX;");
+        assertFieldSignature(OuterRaw.NestedParam.class, "fieldG",
+                "Lorg/jboss/jandex/test/data/OuterRaw$NestedParam<TX;>;");
+        assertFieldSignature(OuterRaw.NestedParamBound.class, "fieldH",
+                "Ljava/util/List<TX;>;");
+        assertFieldSignature(OuterRaw.NestedParamBound.class, "fieldI",
+                "Lorg/jboss/jandex/test/data/OuterRaw$NestedParamBound<Ljava/lang/Integer;>;");
+        assertFieldSignature(OuterRaw.InnerParam.class, "fieldJ",
+                "TX;");
+        assertFieldSignature(OuterRaw.InnerParam.class, "fieldK",
+                "Lorg/jboss/jandex/test/data/OuterRaw$InnerParam<Ljava/lang/Integer;>;");
+        assertFieldSignature(OuterRaw.InnerParamBound.class, "fieldL",
+                "Ljava/util/List<TX;>;");
+        assertFieldSignature(OuterRaw.InnerParamBound.class, "fieldM",
+                "Lorg/jboss/jandex/test/data/OuterRaw$InnerParamBound<TX;>;");
+    }
+
+    @Test
+    public void outerParam() {
+        assertClassSignature(OuterParam.class,
+                "<W:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterParam.NestedRaw.class,
+                null);
+        assertClassSignature(OuterParam.NestedParam.class,
+                "<X:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterParam.NestedParamBound.class,
+                "<X:Ljava/lang/Number;:Ljava/lang/Comparable<TX;>;>Ljava/lang/Object;");
+        assertClassSignature(OuterParam.InnerRaw.class,
+                null);
+        assertClassSignature(OuterParam.InnerParam.class,
+                "<X:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterParam.InnerParamBound.class,
+                "<X:Ljava/lang/Number;:Ljava/lang/Comparable<TX;>;>Ljava/lang/Object;");
+
+        assertMethodSignature(OuterParam.class, "methodA",
+                "(Ljava/lang/String;TW;Lorg/jboss/jandex/test/data/OuterParam<TW;>;)Ljava/lang/String;");
+        assertMethodSignature(OuterParam.class, "methodB",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(TU;TW;Lorg/jboss/jandex/test/data/OuterParam<TW;>;)TT;");
+        assertMethodSignature(OuterParam.NestedRaw.class, "methodC",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;Lorg/jboss/jandex/test/data/OuterParam$NestedRaw;)TT;^Ljava/lang/IllegalArgumentException;^TV;");
+        assertMethodSignature(OuterParam.NestedParam.class, "methodD",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<-TU;>;TX;Lorg/jboss/jandex/test/data/OuterParam$NestedParam<TX;>;)TT;");
+        assertMethodSignature(OuterParam.NestedParamBound.class, "methodE",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<*>;TX;Lorg/jboss/jandex/test/data/OuterParam$NestedParamBound<TX;>;)TT;^TV;");
+        assertMethodSignature(OuterParam.InnerRaw.class, "methodF",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;TW;Lorg/jboss/jandex/test/data/OuterParam<TW;>.InnerRaw;)TT;^Ljava/lang/IllegalArgumentException;^TV;");
+        assertMethodSignature(OuterParam.InnerParam.class, "methodG",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<-TU;>;TX;TW;Lorg/jboss/jandex/test/data/OuterParam<TW;>.InnerParam<TX;>;)TT;");
+        assertMethodSignature(OuterParam.InnerParamBound.class, "methodH",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<*>;TX;TW;Lorg/jboss/jandex/test/data/OuterParam<TW;>.InnerParamBound<TX;>;)TT;^TV;");
+
+        assertFieldSignature(OuterParam.class, "fieldA",
+                "TW;");
+        assertFieldSignature(OuterParam.class, "fieldB",
+                "Ljava/util/List<TW;>;");
+        assertFieldSignature(OuterParam.class, "fieldC",
+                "Ljava/util/List<+TW;>;");
+        assertFieldSignature(OuterParam.class, "fieldD",
+                "Ljava/util/List<-TW;>;");
+        assertFieldSignature(OuterParam.InnerRaw.class, "fieldE",
+                "Ljava/util/List<Lorg/jboss/jandex/test/data/OuterParam<+TW;>.InnerRaw;>;");
+        assertFieldSignature(OuterParam.InnerParam.class, "fieldF",
+                "Ljava/util/List<Lorg/jboss/jandex/test/data/OuterParam<-TW;>.InnerParam<*>;>;");
+        assertFieldSignature(OuterParam.InnerParamBound.class, "fieldG",
+                "Ljava/util/Map<+TX;TW;>;");
+        assertFieldSignature(OuterParam.InnerParamBound.class, "fieldH",
+                "Ljava/util/Map<-TX;Lorg/jboss/jandex/test/data/OuterParam<Ljava/lang/String;>.InnerParamBound<Ljava/lang/Integer;>;>;");
+    }
+
+    @Test
+    public void outerParamBound() {
+        assertClassSignature(OuterParamBound.class,
+                "<W:Ljava/lang/Number;:Ljava/lang/Comparable<TW;>;>Ljava/lang/Object;");
+        assertClassSignature(OuterParamBound.NestedRaw.class,
+                null);
+        assertClassSignature(OuterParamBound.NestedParam.class,
+                "<X:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterParamBound.NestedParamBound.class,
+                "<X:Ljava/lang/Number;:Ljava/lang/Comparable<TX;>;>Ljava/lang/Object;");
+        assertClassSignature(OuterParamBound.InnerRaw.class,
+                null);
+        assertClassSignature(OuterParamBound.InnerParam.class,
+                "<X:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(OuterParamBound.InnerParamBound.class,
+                "<X:Ljava/lang/Number;:Ljava/lang/Comparable<TX;>;>Ljava/lang/Object;");
+
+        assertMethodSignature(OuterParamBound.class, "methodA",
+                "(Ljava/lang/String;TW;Lorg/jboss/jandex/test/data/OuterParamBound<TW;>;)Ljava/lang/String;");
+        assertMethodSignature(OuterParamBound.class, "methodB",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(TU;TW;Lorg/jboss/jandex/test/data/OuterParamBound<TW;>;)TT;");
+        assertMethodSignature(OuterParamBound.NestedRaw.class, "methodC",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;Lorg/jboss/jandex/test/data/OuterParamBound$NestedRaw;)TT;^Ljava/lang/IllegalArgumentException;^TV;");
+        assertMethodSignature(OuterParamBound.NestedParam.class, "methodD",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<-TU;>;TX;Lorg/jboss/jandex/test/data/OuterParamBound$NestedParam<TX;>;)TT;");
+        assertMethodSignature(OuterParamBound.NestedParamBound.class, "methodE",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<*>;TX;Lorg/jboss/jandex/test/data/OuterParamBound$NestedParamBound<TX;>;)TT;^TV;");
+        assertMethodSignature(OuterParamBound.InnerRaw.class, "methodF",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;TW;Lorg/jboss/jandex/test/data/OuterParamBound<TW;>.InnerRaw;)TT;^Ljava/lang/IllegalArgumentException;^TV;");
+        assertMethodSignature(OuterParamBound.InnerParam.class, "methodG",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<-TU;>;TX;TW;Lorg/jboss/jandex/test/data/OuterParamBound<TW;>.InnerParam<TX;>;)TT;");
+        assertMethodSignature(OuterParamBound.InnerParamBound.class, "methodH",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<*>;TX;TW;Lorg/jboss/jandex/test/data/OuterParamBound<TW;>.InnerParamBound<TX;>;)TT;^TV;");
+
+        assertFieldSignature(OuterParamBound.class, "fieldA",
+                "TW;");
+        assertFieldSignature(OuterParamBound.class, "fieldB",
+                "Ljava/util/List<TW;>;");
+        assertFieldSignature(OuterParamBound.class, "fieldC",
+                "Ljava/util/List<+TW;>;");
+        assertFieldSignature(OuterParamBound.class, "fieldD",
+                "Ljava/util/List<-TW;>;");
+        assertFieldSignature(OuterParamBound.InnerRaw.class, "fieldE",
+                "Ljava/util/List<Lorg/jboss/jandex/test/data/OuterParamBound<+Ljava/lang/Integer;>.InnerParam<-Ljava/lang/String;>;>;");
+        assertFieldSignature(OuterParamBound.InnerParam.class, "fieldF",
+                "Ljava/util/List<Lorg/jboss/jandex/test/data/OuterParamBound<Ljava/lang/Integer;>.InnerParam<+TW;>;>;");
+        assertFieldSignature(OuterParamBound.InnerParam.class, "fieldG",
+                "Ljava/util/Map<TX;-TW;>;");
+        assertFieldSignature(OuterParamBound.InnerParamBound.class, "fieldH",
+                "Ljava/util/List<Lorg/jboss/jandex/test/data/OuterParamBound<TX;>.InnerParamBound<TW;>;>;");
+        assertFieldSignature(OuterParamBound.InnerParamBound.class, "fieldI",
+                "Ljava/util/Map<+TX;TW;>;");
+    }
+
+    @Test
+    public void classInheritance() {
+        assertClassSignature(ClassInheritance.PlainClass.class,
+                null);
+        assertClassSignature(ClassInheritance.ParamClass.class,
+                "<T:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(ClassInheritance.ParamBoundClass.class,
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Ljava/lang/Object;");
+        assertClassSignature(ClassInheritance.PlainInterface.class,
+                null);
+        assertClassSignature(ClassInheritance.ParamInterface.class,
+                "<T:Ljava/lang/Object;>Ljava/lang/Object;");
+        assertClassSignature(ClassInheritance.ParamBoundInterface.class,
+                "<T::Ljava/lang/Comparable<Ljava/lang/Integer;>;:Ljava/io/Serializable;>Ljava/lang/Object;");
+        assertClassSignature(ClassInheritance.PlainClassExtendsPlainClass.class,
+                null);
+        assertClassSignature(ClassInheritance.PlainClassExtendsParamClass.class,
+                "Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.PlainClassExtendsParamBoundClass.class,
+                "Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsPlainClass.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$PlainClass;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsParamClass1.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsParamClass2.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<TT;>;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsParamBoundClass.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsPlainClass.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$PlainClass;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamClass1.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamClass2.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<TT;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamBoundClass1.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamBoundClass2.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<TT;>;");
+        assertClassSignature(ClassInheritance.PlainClassImplementsPlainInterface.class,
+                null);
+        assertClassSignature(ClassInheritance.PlainClassImplementsParamInterface.class,
+                "Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.PlainClassImplementsParamBoundInterface.class,
+                "Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamClassImplementsPlainInterface.class,
+                "<T:Ljava/lang/Object;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$PlainInterface;");
+        assertClassSignature(ClassInheritance.ParamClassImplementsParamInterface1.class,
+                "<T:Ljava/lang/Object;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.ParamClassImplementsParamInterface2.class,
+                "<T:Ljava/lang/Object;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<TT;>;");
+        assertClassSignature(ClassInheritance.ParamClassImplementsParamBoundInterface.class,
+                "<T:Ljava/lang/Object;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassImplementsPlainInterface.class,
+                "<T:Ljava/lang/Integer;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$PlainInterface;");
+        assertClassSignature(ClassInheritance.ParamBoundClassImplementsParamInterface1.class,
+                "<T:Ljava/lang/Integer;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassImplementsParamInterface2.class,
+                "<T:Ljava/lang/Integer;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<TT;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassImplementsParamBoundInterface1.class,
+                "<T:Ljava/lang/Integer;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassImplementsParamBoundInterface2.class,
+                "<T:Ljava/lang/Integer;>Ljava/lang/Object;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<TT;>;");
+        assertClassSignature(ClassInheritance.PlainClassExtendsPlainClassImplementsPlainInterface.class,
+                null);
+        assertClassSignature(ClassInheritance.PlainClassExtendsParamClassImplementsParamInterface.class,
+                "Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.PlainClassExtendsParamBoundClassImplementsParamBoundInterface.class,
+                "Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<Ljava/lang/Integer;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsPlainClassImplementsPlainInterface.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$PlainClass;Lorg/jboss/jandex/test/data/ClassInheritance$PlainInterface;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsParamClassImplementsParamInterface1.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsParamClassImplementsParamInterface2.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<TT;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<TT;>;");
+        assertClassSignature(ClassInheritance.ParamClassExtendsParamBoundClassImplementsParamBoundInterface.class,
+                "<T:Ljava/lang/Object;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<Ljava/lang/Integer;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsPlainClassImplementsPlainInterface.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$PlainClass;Lorg/jboss/jandex/test/data/ClassInheritance$PlainInterface;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamClassImplementsParamInterface1.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamClassImplementsParamInterface2.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<TT;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<TT;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamBoundClassImplementsParamBoundInterface1.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<Ljava/lang/Integer;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<Ljava/lang/Integer;>;");
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamBoundClassImplementsParamBoundInterface2.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundClass<TT;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamBoundInterface<TT;>;");
+
+        assertClassSignature(ClassInheritance.OuterParam.InnerParam.InnerInnerRaw.InnerInnerInnerParam.Test.class,
+                "<X:Ljava/lang/String;Y:Ljava/lang/Integer;>Lorg/jboss/jandex/test/data/ClassInheritance$OuterParam<TX;>.InnerParam<TY;>.InnerInnerRaw.InnerInnerInnerParam<Ljava/lang/String;>;Lorg/jboss/jandex/test/data/ClassInheritance$OuterParam$NestedParam<TV;>;");
+    }
+
+    @Test
+    public void withSubstitution() {
+        assertClassSignature(OuterParamBound.class,
+                "<W:Ljava/lang/Number;:Ljava/lang/Comparable<Ljava/lang/String;>;>Ljava/lang/Object;",
+                id -> "W".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertClassSignature(ClassInheritance.ParamBoundInterface.class,
+                "<T::Ljava/lang/Comparable<Ljava/lang/Integer;>;:Ljava/io/Serializable;>Ljava/lang/Object;",
+                id -> "T".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertClassSignature(ClassInheritance.ParamBoundClassExtendsParamClassImplementsParamInterface2.class,
+                "<T:Ljava/lang/Integer;:Ljava/lang/Comparable<Ljava/lang/Integer;>;>Lorg/jboss/jandex/test/data/ClassInheritance$ParamClass<Ljava/lang/String;>;Lorg/jboss/jandex/test/data/ClassInheritance$ParamInterface<Ljava/lang/String;>;",
+                id -> "T".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+
+        assertMethodSignature(OuterRaw.class, "methodB",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<Ljava/lang/String;>;V:Ljava/lang/Exception;>(Ljava/lang/String;Lorg/jboss/jandex/test/data/OuterRaw;)TT;",
+                id -> "U".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertMethodSignature(OuterRaw.class, "methodB",
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<Ljava/lang/String;>;U::Ljava/lang/Comparable<Ljava/lang/String;>;V:Ljava/lang/Exception;>(Ljava/lang/String;Lorg/jboss/jandex/test/data/OuterRaw;)Ljava/lang/String;",
+                id -> "T".equals(id) || "U".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+
+        assertFieldSignature(OuterRaw.InnerParamBound.class, "fieldL",
+                "Ljava/util/List<Ljava/lang/String;>;",
+                id -> "X".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+        assertFieldSignature(OuterRaw.InnerParamBound.class, "fieldM",
+                "Lorg/jboss/jandex/test/data/OuterRaw$InnerParamBound<Ljava/lang/String;>;",
+                id -> "X".equals(id) ? ClassType.create(DotName.STRING_NAME) : null);
+    }
+
+    private static void assertClassSignature(Class<?> clazz, String expectedSignature) {
+        assertClassSignature(clazz, expectedSignature, GenericSignature.NO_SUBSTITUTION);
+    }
+
+    private static void assertClassSignature(Class<?> clazz, String expectedSignature,
+            Function<String, Type> subst) {
+        ClassInfo classInfo = index.getClassByName(clazz);
+        if (classInfo != null) {
+            String actualSignature = classInfo.genericSignatureIfRequired(subst);
+            assertEquals(expectedSignature, actualSignature);
+            return;
+        }
+
+        fail("Couldn't find class " + clazz.getName() + " in test index");
+    }
+
+    private static void assertMethodSignature(Class<?> clazz, String method, String expectedSignature) {
+        assertMethodSignature(clazz, method, expectedSignature, GenericSignature.NO_SUBSTITUTION);
+    }
+
+    private static void assertMethodSignature(Class<?> clazz, String method, String expectedSignature,
+            Function<String, Type> subst) {
+        ClassInfo classInfo = index.getClassByName(clazz);
+        if (classInfo != null) {
+            MethodInfo methodInfo = classInfo.firstMethod(method);
+            if (methodInfo != null) {
+                String actualSignature = methodInfo.genericSignatureIfRequired(subst);
+                assertEquals(expectedSignature, actualSignature);
+                return;
+            }
+        }
+
+        fail("Couldn't find method " + clazz.getName() + "#" + method + " in test index");
+    }
+
+    private static void assertFieldSignature(Class<?> clazz, String field, String expectedSignature) {
+        assertFieldSignature(clazz, field, expectedSignature, GenericSignature.NO_SUBSTITUTION);
+    }
+
+    private static void assertFieldSignature(Class<?> clazz, String field, String expectedSignature,
+            Function<String, Type> subst) {
+        ClassInfo classInfo = index.getClassByName(clazz);
+        if (classInfo != null) {
+            FieldInfo fieldInfo = classInfo.field(field);
+            if (fieldInfo != null) {
+                String actualSignature = fieldInfo.genericSignatureIfRequired(subst);
+                assertEquals(expectedSignature, actualSignature);
+                return;
+            }
+        }
+
+        fail("Couldn't find field " + clazz.getName() + "#" + field + " in test index");
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/data/ClassInheritance.java
+++ b/core/src/test/java/org/jboss/jandex/test/data/ClassInheritance.java
@@ -1,0 +1,203 @@
+package org.jboss.jandex.test.data;
+
+import java.io.Serializable;
+
+public class ClassInheritance {
+    public static class PlainClass {
+    }
+
+    public static class ParamClass<T> {
+    }
+
+    public static class ParamBoundClass<T extends Number & Comparable<Integer>> {
+    }
+
+    public interface PlainInterface {
+    }
+
+    public interface ParamInterface<T> {
+    }
+
+    public interface ParamBoundInterface<T extends Comparable<Integer> & Serializable> {
+    }
+
+    // ---
+
+    public static class PlainClassExtendsPlainClass
+            extends PlainClass {
+    }
+
+    public static class PlainClassExtendsParamClass
+            extends ParamClass<String> {
+    }
+
+    public static class PlainClassExtendsParamBoundClass
+            extends ParamBoundClass<Integer> {
+    }
+
+    public static class ParamClassExtendsPlainClass<T>
+            extends PlainClass {
+    }
+
+    public static class ParamClassExtendsParamClass1<T>
+            extends ParamClass<String> {
+    }
+
+    public static class ParamClassExtendsParamClass2<T>
+            extends ParamClass<T> {
+    }
+
+    public static class ParamClassExtendsParamBoundClass<T>
+            extends ParamBoundClass<Integer> {
+    }
+
+    public static class ParamBoundClassExtendsPlainClass<T extends Integer & Comparable<Integer>>
+            extends PlainClass {
+    }
+
+    public static class ParamBoundClassExtendsParamClass1<T extends Integer & Comparable<Integer>>
+            extends ParamClass<String> {
+    }
+
+    public static class ParamBoundClassExtendsParamClass2<T extends Integer & Comparable<Integer>>
+            extends ParamClass<T> {
+    }
+
+    public static class ParamBoundClassExtendsParamBoundClass1<T extends Integer & Comparable<Integer>>
+            extends ParamBoundClass<Integer> {
+    }
+
+    public static class ParamBoundClassExtendsParamBoundClass2<T extends Integer & Comparable<Integer>>
+            extends ParamBoundClass<T> {
+    }
+
+    // ---
+
+    public static class PlainClassImplementsPlainInterface
+            implements PlainInterface {
+    }
+
+    public static class PlainClassImplementsParamInterface
+            implements ParamInterface<String> {
+    }
+
+    public static class PlainClassImplementsParamBoundInterface
+            implements ParamBoundInterface<Integer> {
+    }
+
+    public static class ParamClassImplementsPlainInterface<T>
+            implements PlainInterface {
+    }
+
+    public static class ParamClassImplementsParamInterface1<T>
+            implements ParamInterface<String> {
+    }
+
+    public static class ParamClassImplementsParamInterface2<T>
+            implements ParamInterface<T> {
+    }
+
+    public static class ParamClassImplementsParamBoundInterface<T>
+            implements ParamBoundInterface<Integer> {
+    }
+
+    public static class ParamBoundClassImplementsPlainInterface<T extends Integer>
+            implements PlainInterface {
+    }
+
+    public static class ParamBoundClassImplementsParamInterface1<T extends Integer>
+            implements ParamInterface<String> {
+    }
+
+    public static class ParamBoundClassImplementsParamInterface2<T extends Integer>
+            implements ParamInterface<T> {
+    }
+
+    public static class ParamBoundClassImplementsParamBoundInterface1<T extends Integer>
+            implements ParamBoundInterface<Integer> {
+    }
+
+    public static class ParamBoundClassImplementsParamBoundInterface2<T extends Integer>
+            implements ParamBoundInterface<T> {
+    }
+
+    // ---
+
+    public static class PlainClassExtendsPlainClassImplementsPlainInterface
+            extends PlainClass
+            implements PlainInterface {
+    }
+
+    public static class PlainClassExtendsParamClassImplementsParamInterface
+            extends ParamClass<String>
+            implements ParamInterface<String> {
+    }
+
+    public static class PlainClassExtendsParamBoundClassImplementsParamBoundInterface
+            extends ParamBoundClass<Integer>
+            implements ParamBoundInterface<Integer> {
+    }
+
+    public static class ParamClassExtendsPlainClassImplementsPlainInterface<T>
+            extends PlainClass
+            implements PlainInterface {
+    }
+
+    public static class ParamClassExtendsParamClassImplementsParamInterface1<T>
+            extends ParamClass<String>
+            implements ParamInterface<String> {
+    }
+
+    public static class ParamClassExtendsParamClassImplementsParamInterface2<T>
+            extends ParamClass<T>
+            implements ParamInterface<T> {
+    }
+
+    public static class ParamClassExtendsParamBoundClassImplementsParamBoundInterface<T>
+            extends ParamBoundClass<Integer>
+            implements ParamBoundInterface<Integer> {
+    }
+
+    public static class ParamBoundClassExtendsPlainClassImplementsPlainInterface<T extends Integer & Comparable<Integer>>
+            extends PlainClass
+            implements PlainInterface {
+    }
+
+    public static class ParamBoundClassExtendsParamClassImplementsParamInterface1<T extends Integer & Comparable<Integer>>
+            extends ParamClass<String>
+            implements ParamInterface<String> {
+    }
+
+    public static class ParamBoundClassExtendsParamClassImplementsParamInterface2<T extends Integer & Comparable<Integer>>
+            extends ParamClass<T>
+            implements ParamInterface<T> {
+    }
+
+    public static class ParamBoundClassExtendsParamBoundClassImplementsParamBoundInterface1<T extends Integer & Comparable<Integer>>
+            extends ParamBoundClass<Integer>
+            implements ParamBoundInterface<Integer> {
+    }
+
+    public static class ParamBoundClassExtendsParamBoundClassImplementsParamBoundInterface2<T extends Integer & Comparable<Integer>>
+            extends ParamBoundClass<T>
+            implements ParamBoundInterface<T> {
+    }
+
+    // ---
+
+    public static class OuterParam<T extends Serializable> {
+        public interface NestedParam<U> {
+        }
+
+        public class InnerParam<U extends Number> {
+            public class InnerInnerRaw {
+                public class InnerInnerInnerParam<V> {
+                    public class Test<X extends String, Y extends Integer>
+                            extends OuterParam<X>.InnerParam<Y>.InnerInnerRaw.InnerInnerInnerParam<String>
+                            implements NestedParam<V> {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/data/OuterParam.java
+++ b/core/src/test/java/org/jboss/jandex/test/data/OuterParam.java
@@ -1,0 +1,72 @@
+package org.jboss.jandex.test.data;
+
+import java.util.List;
+import java.util.Map;
+
+public class OuterParam<W> {
+    public W fieldA;
+
+    public List<W> fieldB;
+
+    public List<? extends W> fieldC;
+
+    public List<? super W> fieldD;
+
+    public String methodA(String arg, W arg2, OuterParam<W> self) throws IllegalArgumentException {
+        return null;
+    }
+
+    public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodB(
+            U arg, W arg2, OuterParam<W> self) {
+        return null;
+    }
+
+    public static class NestedRaw {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodC(
+                List<? extends U> arg, NestedRaw self) throws IllegalArgumentException, V {
+            return null;
+        }
+    }
+
+    public static class NestedParam<X> {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodD(
+                List<? super U> arg, X arg2, NestedParam<X> self) throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    public static class NestedParamBound<X extends Number & Comparable<X>> {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodE(
+                List<?> arg, X arg2, NestedParamBound<X> self) throws V {
+            return null;
+        }
+    }
+
+    public class InnerRaw {
+        public List<OuterParam<? extends W>.InnerRaw> fieldE;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodF(
+                List<? extends U> arg, W arg2, InnerRaw self) throws IllegalArgumentException, V {
+            return null;
+        }
+    }
+
+    public class InnerParam<X> {
+        public List<OuterParam<? super W>.InnerParam<?>> fieldF;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodG(
+                List<? super U> arg, X arg2, W arg3, InnerParam<X> self) throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    public class InnerParamBound<X extends Number & Comparable<X>> {
+        public Map<? extends X, W> fieldG;
+        public Map<? super X, OuterParam<String>.InnerParamBound<Integer>> fieldH;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodH(
+                List<?> arg, X arg2, W arg3, InnerParamBound<X> self) throws V {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/data/OuterParamBound.java
+++ b/core/src/test/java/org/jboss/jandex/test/data/OuterParamBound.java
@@ -1,0 +1,73 @@
+package org.jboss.jandex.test.data;
+
+import java.util.List;
+import java.util.Map;
+
+public class OuterParamBound<W extends Number & Comparable<W>> {
+    public W fieldA;
+
+    public List<W> fieldB;
+
+    public List<? extends W> fieldC;
+
+    public List<? super W> fieldD;
+
+    public String methodA(String arg, W arg2, OuterParamBound<W> self) throws IllegalArgumentException {
+        return null;
+    }
+
+    public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodB(
+            U arg, W arg2, OuterParamBound<W> self) {
+        return null;
+    }
+
+    public static class NestedRaw {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodC(
+                List<? extends U> arg, NestedRaw self) throws IllegalArgumentException, V {
+            return null;
+        }
+    }
+
+    public static class NestedParam<X> {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodD(
+                List<? super U> arg, X arg2, NestedParam<X> self) throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    public static class NestedParamBound<X extends Number & Comparable<X>> {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodE(
+                List<?> arg, X arg2, NestedParamBound<X> self) throws V {
+            return null;
+        }
+    }
+
+    public class InnerRaw {
+        public List<OuterParamBound<? extends Integer>.InnerParam<? super String>> fieldE;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodF(
+                List<? extends U> arg, W arg2, InnerRaw self) throws IllegalArgumentException, V {
+            return null;
+        }
+    }
+
+    public class InnerParam<X> {
+        public List<OuterParamBound<Integer>.InnerParam<? extends W>> fieldF;
+        public Map<X, ? super W> fieldG;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodG(
+                List<? super U> arg, X arg2, W arg3, InnerParam<X> self) throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    public class InnerParamBound<X extends Number & Comparable<X>> {
+        public List<OuterParamBound<X>.InnerParamBound<W>> fieldH;
+        public Map<? extends X, W> fieldI;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodH(
+                List<?> arg, X arg2, W arg3, InnerParamBound<X> self) throws V {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/data/OuterRaw.java
+++ b/core/src/test/java/org/jboss/jandex/test/data/OuterRaw.java
@@ -1,0 +1,78 @@
+package org.jboss.jandex.test.data;
+
+import java.util.List;
+
+public class OuterRaw {
+    public String fieldA;
+
+    public List<String> fieldB;
+
+    public List<?> fieldC;
+
+    public List<? extends CharSequence> fieldD;
+
+    public List<? super String> fieldE;
+
+    public String methodA(String arg, OuterRaw self) throws IllegalArgumentException {
+        return null;
+    }
+
+    public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodB(
+            U arg, OuterRaw self) {
+        return null;
+    }
+
+    public static class NestedRaw {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodC(
+                List<? extends U> arg, NestedRaw self) throws IllegalArgumentException, V {
+            return null;
+        }
+    }
+
+    public static class NestedParam<X> {
+        public X fieldF;
+        public NestedParam<X> fieldG;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodD(
+                List<? super U> arg, X arg2, NestedParam<X> self) throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    public static class NestedParamBound<X extends Number & Comparable<X>> {
+        public List<X> fieldH;
+        public NestedParamBound<Integer> fieldI;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodE(
+                List<?> arg, X arg2, NestedParamBound<X> self) throws V {
+            return null;
+        }
+    }
+
+    public class InnerRaw {
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodF(
+                List<? extends U> arg, InnerRaw self) throws IllegalArgumentException, V {
+            return null;
+        }
+    }
+
+    public class InnerParam<X> {
+        public X fieldJ;
+        public InnerParam<Integer> fieldK;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodG(
+                List<? super U> arg, X arg2, InnerParam<X> self) throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    public class InnerParamBound<X extends Number & Comparable<X>> {
+        public List<X> fieldL;
+        public InnerParamBound<X> fieldM;
+
+        public <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T methodH(
+                List<?> arg, X arg2, InnerParamBound<X> self) throws V {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This API includes type variable substitution, which is used on several places in Quarkus. If the substitution function returns a type for some type variable identifier, the reconstructed descriptor/signature contains a descriptor/signature of the provided type instead of the original type variable.