### PR TITLE
Ignore invalid generic signatures during indexing

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -1709,13 +1709,6 @@ public final class Indexer {
         signaturePresent.put(target, null);
     }
 
-    private void parseClassSignature(String signature, ClassInfo clazz) {
-        GenericSignatureParser.ClassSignature classSignature = signatureParser.parseClassSignature(signature);
-        clazz.setInterfaceTypes(classSignature.interfaces());
-        clazz.setSuperClassType(classSignature.superClass());
-        clazz.setTypeParameters(classSignature.parameters());
-    }
-
     private void applySignatures() {
         int end = signatures.size();
 
@@ -1747,13 +1740,44 @@ public final class Indexer {
         }
     }
 
+    private void parseClassSignature(String signature, ClassInfo clazz) {
+        GenericSignatureParser.ClassSignature classSignature;
+        try {
+            classSignature = signatureParser.parseClassSignature(signature);
+        } catch (Exception e) {
+            // invalid generic signature
+            // let's just pretend that no signature exists
+            return;
+        }
+
+        clazz.setInterfaceTypes(classSignature.interfaces());
+        clazz.setSuperClassType(classSignature.superClass());
+        clazz.setTypeParameters(classSignature.parameters());
+    }
+
     private void parseFieldSignature(String signature, FieldInfo field) {
-        Type type = signatureParser.parseFieldSignature(signature);
+        Type type;
+        try {
+            type = signatureParser.parseFieldSignature(signature);
+        } catch (Exception e) {
+            // invalid generic signature
+            // let's just pretend that no signature exists
+            return;
+        }
+
         field.setType(type);
     }
 
     private void parseMethodSignature(String signature, MethodInfo method) {
-        GenericSignatureParser.MethodSignature methodSignature = signatureParser.parseMethodSignature(signature);
+        GenericSignatureParser.MethodSignature methodSignature;
+        try {
+            methodSignature = signatureParser.parseMethodSignature(signature);
+        } catch (Exception e) {
+            // invalid generic signature
+            // let's just pretend that no signature exists
+            return;
+        }
+
         method.setParameters(methodSignature.methodParameters());
         method.setReturnType(methodSignature.returnType());
         method.setTypeParameters(methodSignature.typeParameters());
@@ -1763,8 +1787,16 @@ public final class Indexer {
     }
 
     private void parseRecordComponentSignature(String signature, RecordComponentInfo recordComponent) {
-        // per JVM Specification, signatures stored for records must be field signatures
-        Type type = signatureParser.parseFieldSignature(signature);
+        Type type = null;
+        try {
+            // per JVM Specification, signatures stored for records must be field signatures
+            type = signatureParser.parseFieldSignature(signature);
+        } catch (Exception e) {
+            // invalid generic signature
+            // let's just pretend that no signature exists
+            return;
+        }
+
         recordComponent.setType(type);
     }
 

--- a/core/src/test/java/org/jboss/jandex/test/LambdaSignatureTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/LambdaSignatureTest.java
@@ -1,0 +1,35 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class LambdaSignatureTest {
+    static class MyList<T> {
+        MyList(T... elements) {
+        }
+
+        static Supplier<? extends MyList<Object>> supplier() {
+            // for this lambda:
+            // - javac emits a synthetic static method without signature
+            // - ecj emits a synthetic static method with an invalid signature
+            return MyList<Object>::new;
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(MyList.class);
+        doTest(index);
+        doTest(IndexingUtil.roundtrip(index));
+    }
+
+    private void doTest(Index index) {
+        assertNotNull(index.getClassByName(MyList.class));
+    }
+}


### PR DESCRIPTION
In case an invalid generic signature appears in the bytecode, indexing fails with an exception. This is unfriendly, because ECJ emits invalid generic signatures on pretty basic code (a synthetic static method generated for a lambda), so ECJ-generated code cannot be indexed.

This commit simply ignores a generic signature that cannot be parsed.

Fixes #32