### PR TITLE
Build generates reproducible jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -27,7 +28,7 @@
         <version.exec-maven-plugin>3.0.0</version.exec-maven-plugin>
         <version.junit>5.8.2</version.junit>
         <version.maven>3.8.1</version.maven>
-        <version.maven-bundle-plugin>5.1.2</version.maven-bundle-plugin>
+        <version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
         <version.maven-compiler-plugin>3.10.1</version.maven-compiler-plugin>
         <version.maven-dependency-plugin>3.3.0</version.maven-dependency-plugin>
         <version.maven-invoker-plugin>3.2.2</version.maven-invoker-plugin>


### PR DESCRIPTION
Per: https://maven.apache.org/guides/mini/guide-reproducible-builds.html

* Updates maven-bundle-plugin to 5.1.8 (which removes the `Bnd-LastModified` field from the manifest)
* Adds `project.build.outputTimestamp` to the root pom,  the release plugin will update this value when preparing a release

NOTE: The `test-data` build is NOT reproducible as the jar is patched out of band using the `jar` command