### PR TITLE
Build custom buffered input stream that can reuse tmp read buffers across indexing ops

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -274,10 +274,26 @@ public final class Indexer {
     }
 
     private static byte[] sizeToFit(byte[] buf, int needed, int offset, int remainingEntries) {
-        if (offset + needed > buf.length) {
-            buf = Arrays.copyOf(buf, buf.length + Math.max(needed, (remainingEntries + 1) * 20));
+        int oldLength = buf.length;
+        if (offset + needed > oldLength) {
+            int newLength = newLength(oldLength, needed, oldLength >> 1);
+            buf = Arrays.copyOf(buf, newLength);
         }
         return buf;
+    }
+
+    private static int newLength(int oldLength, int minGrowth, int prefGrowth) {
+        int prefLength = oldLength + Math.max(minGrowth, prefGrowth);
+        return prefLength > 0 ? prefLength : minLength(oldLength, minGrowth);
+    }
+
+    private static int minLength(int oldLength, int minGrowth) {
+        int minLength = oldLength + minGrowth;
+        if (minLength < 0) {
+            throw new OutOfMemoryError("Cannot allocate a large enough array: " +
+                    oldLength + " + " + minGrowth + " is too large");
+        }
+        return minLength;
     }
 
     private static void skipFully(InputStream s, long n) throws IOException {

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -2138,9 +2138,51 @@ public final class Indexer {
 
         pos++;
 
-        // DataInputStream needs to read the length again
         int len = (pool[pos] & 0xFF) << 8 | (pool[pos + 1] & 0xFF);
+        final String asciiString = tryDecodeAsciiEntry(pool, pos + 2, len);
+        if (asciiString != null) {
+            return asciiString;
+        }
+        // slow-path: TO IMPROVE!
+        // DataInputStream needs to read the length again
         return new DataInputStream(new ByteArrayInputStream(pool, pos, len + 2)).readUTF();
+    }
+
+    private static String tryDecodeAsciiEntry(byte[] chars, int pos, int len) {
+        final int longRounds = len >>> 3;
+        int off = pos;
+        for (int i = 0; i < longRounds; i++) {
+            final long batch = ((long) chars[off]) << 56 |
+                    ((long) chars[off + 1]) << 48 |
+                    ((long) chars[off + 2]) << 40 |
+                    ((long) chars[off + 3]) << 32 |
+                    chars[off + 4] << 24 |
+                    chars[off + 5] << 16 |
+                    chars[off + 6] << 8 |
+                    chars[off + 7];
+            // it's checking that each char is <= 127 in one go
+            if ((batch & 0x80_80_80_80_80_80_80_80L) != 0) {
+                return null;
+            }
+            off += Long.BYTES;
+        }
+        final int byteRounds = len & 7;
+        if (byteRounds > 0) {
+            for (int i = 0; i < byteRounds; i++) {
+                if ((chars[off + i] & 0x80) != 0) {
+                    return null;
+                }
+            }
+        }
+        // check https://bugs.openjdk.org/browse/JDK-8295496
+        if (pos == 0) {
+            if (len == chars.length) {
+                return new String(chars, 0, 0, chars.length);
+            }
+            return new String(chars, 0, 0, len);
+        }
+        // slow path :"(
+        return new String(chars, 0, pos, len);
     }
 
     private byte[] decodeUtf8EntryAsBytes(int index) {


### PR DESCRIPTION
Deloying a wildfly instance with many JPA models shows that buffered files reads allocate, by default, a 8K byte[] buffer per each indexed file, causing many out of TLAB allocations.

Ideally we could reuse such buffer across different indexed ops, saving zeroing and TLAB bandwidth that could be used elsewhere.

I'm assuming 2 things:
- the same `Indexer` to be reused
- `Indexer` is a single-threaded class that can just borrow/release the same buffer again and again without being bothered by concurrency issues

@Ladicek these are valid assumptions?
