### PR TITLE
Update Java versions in CI: remove 19 and 20-ea, add 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         - 8
         - 11
         - 17
-        - 19
-        - 20-ea
+        - 20
+        #- 21-ea
         compiler:
         - javac
         - ecj


### PR DESCRIPTION
Temurin doesn't seem to have a 21-ea release available, so that will have to wait for later.