### PR TITLE
support directory in jar

### DIFF
--- a/maven-plugin/src/it/jar/verify.groovy
+++ b/maven-plugin/src/it/jar/verify.groovy
@@ -6,6 +6,7 @@ assert jarFile.exists() : "File ${jarFile} does not exist"
 assert jarFile.length() > 0 : "File ${jarFile} is empty"
 
 def jar = new ZipFile(jarFile)
+assert jar.getEntry("META-INF/") != null : "JAR ${jarFile} doesn't contain a META-INF directory"
 def indexEntry = jar.getEntry("META-INF/jandex.idx")
 assert indexEntry != null : "JAR ${jarFile} doesn't contain an index"
 

--- a/maven-plugin/src/main/java/org/jboss/jandex/maven/JandexJarGoal.java
+++ b/maven-plugin/src/main/java/org/jboss/jandex/maven/JandexJarGoal.java
@@ -87,7 +87,7 @@ public class JandexJarGoal extends AbstractMojo {
             Enumeration<? extends ZipEntry> entries = zip.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
-                if (entry.isDirectory() || entry.getName().equals(indexName)) {
+                if (entry.getName().equals(indexName)) {
                     continue;
                 }
 


### PR DESCRIPTION
 support directory in jar,  classloader method: classloader.getResource(entryName) when the entryName is a drectory ,this method would return null.In some opensource tools use this feature to load the resouces in the same folder 
would faile

Resolves #314