### PR TITLE
Reduce allocations when creating immutable array-backed lists

### DIFF
--- a/core/src/main/java/org/jboss/jandex/AnnotationInstance.java
+++ b/core/src/main/java/org/jboss/jandex/AnnotationInstance.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 /**
  * An annotation instance represents a specific usage of an annotation on a
- * target. It contains a set of values, as well as a reference to the target
+ * target. It contains a set of members, as well as a reference to the target
  * itself (e.g. class, field, method, etc).
  *
  * <p>
@@ -131,12 +131,12 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Construct a new mock annotation instance. The passed values array will be defensively copied.
+     * Construct a new mock annotation instance. The passed {@code values} array will be defensively copied.
      * It is assumed that the annotation is {@link #runtimeVisible()}.
      *
      * @param name the name of the annotation instance
      * @param target the thing the annotation is declared on
-     * @param values the values of this annotation instance
+     * @param values the members of this annotation instance
      * @return the new mock Annotation Instance
      */
     public static AnnotationInstance create(DotName name, AnnotationTarget target, AnnotationValue[] values) {
@@ -144,12 +144,12 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Construct a new mock annotation instance. The passed values array will be defensively copied.
+     * Construct a new mock annotation instance. The passed {@code values} array will be defensively copied.
      *
      * @param name the name of the annotation instance
      * @param visible whether the annotation is visible at runtime via the reflection API
      * @param target the thing the annotation is declared on
-     * @param values the values of this annotation instance
+     * @param values the members of this annotation instance
      * @return the new mock Annotation Instance
      */
     public static AnnotationInstance create(DotName name, boolean visible, AnnotationTarget target,
@@ -173,12 +173,12 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Construct a new mock annotation instance. The passed values list will be defensively copied.
+     * Construct a new mock annotation instance. The passed {@code values} list will be defensively copied.
      * It is assumed that the annotation is {@link #runtimeVisible()}.
      *
      * @param name the name of the annotation instance
      * @param target the thing the annotation is declared on
-     * @param values the values of this annotation instance
+     * @param values the members of this annotation instance
      * @return the new mock Annotation Instance
      */
     public static AnnotationInstance create(DotName name, AnnotationTarget target, List<AnnotationValue> values) {
@@ -186,12 +186,12 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Construct a new mock annotation instance. The passed values list will be defensively copied.
+     * Construct a new mock annotation instance. The passed {@code values} list will be defensively copied.
      *
      * @param name the name of the annotation instance
      * @param visible whether the annotation is visible at runtime via the reflection API
      * @param target the thing the annotation is declared on
-     * @param values the values of this annotation instance
+     * @param values the members of this annotation instance
      * @return the new mock Annotation Instance
      */
     public static AnnotationInstance create(DotName name, boolean visible, AnnotationTarget target,
@@ -222,10 +222,10 @@ public final class AnnotationInstance {
     }
 
     /**
-     * The Java element that this annotation was declared on. This can be
-     * a class, a field, a method, or a method parameter. In addition it may
-     * be null if this instance is a nested annotation, in which case there is
-     * no target.
+     * The program element that this annotation was declared on. This can be
+     * a class, a field, a method, a method parameter, or a type in case of
+     * type annotations. In addition, it may be {@code null} if this instance
+     * is a nested annotation, in which case there is no target.
      *
      * @return the target this annotation instance refers to
      */
@@ -234,13 +234,13 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Returns a value that corresponds with the specified parameter name.
-     * If the parameter was not specified by this instance then null is
-     * returned. Note that this also applies to a defaulted parameter,
-     * which is not recorded in the target class.
+     * Returns the member of this annotation that has the specified name.
+     * If the member was not specified by this instance, {@code null} is
+     * returned. Note that this also applies to a defaulted member,
+     * whose value is not recorded in the target class file.
      *
-     * @param name the parameter name
-     * @return the value of the specified parameter, or null if not provided
+     * @param name the name of the annotation member
+     * @return the annotation member with specified name, or {@code null}
      */
     public AnnotationValue value(final String name) {
         int result = Arrays.binarySearch(values, name, new Comparator<Object>() {
@@ -252,34 +252,32 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Returns the value that is associated with the special default "value"
-     * parameter.
+     * Returns the member that has the special default name {@code value}.
      *
-     * @return the "value" value
+     * @return the {@code value} member
      */
     public AnnotationValue value() {
         return value("value");
     }
 
     /**
-     * Returns a value that corresponds with the specified parameter name,
+     * Returns the member of this annotation that has the specified name,
      * accounting for its default value. Since an annotation's defaults are
      * only stored on the annotation's defining class, and not usages of the
-     * annotation, an index containing the Annotation class must be provided
+     * annotation, an index containing the annotation class must be provided
      * as a parameter. If the index does not contain the defining annotation
-     * class, then an <code>IllegalArgumentException</code> will be thrown to
+     * class, then an {@code IllegalArgumentException} will be thrown to
      * prevent non-deterministic results.
      *
      * <p>
-     * If the parameter was not specified by this instance, then the
-     * annotation's <code>ClassInfo</code> is checked for a default value.
-     * If there is a default, that value is returned. Otherwise null is
-     * returned.
+     * If the member was not specified by this annotation instance, then the
+     * annotation's {@code ClassInfo} is checked for a default value. If there
+     * is a default, that value is returned. Otherwise {@code null} is returned.
      * </p>
      *
      * @param index the index containing the defining annotation class
-     * @param name the name of the annotation parameter
-     * @return the value of the specified parameter, the default, or null
+     * @param name the name of the annotation member
+     * @return the annotation member with specified name, or {@code null}
      * @throws IllegalArgumentException if index does not contain the defining
      *         annotation class
      * @since 2.1
@@ -300,23 +298,22 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Returns the value that is associated with the special default "value"
-     * parameter, also accounting for a value default. Since an annotation's
-     * defaults are only stored on the annotation's defining class, and not
-     * usages of the annotation, an index containing the Annotation class must
-     * be provided as a parameter. If the index does not contain the defining
-     * annotation class, then an <code>IllegalArgumentException</code> will be
-     * thrown to prevent non-deterministic results.
+     * Returns the member of this annotation that has special name {@code value},
+     * accounting for its default value. Since an annotation's defaults are only
+     * stored on the annotation's defining class, and not usages of the annotation,
+     * an index containing the annotation class must be provided as a parameter.
+     * If the index does not contain the defining annotation class, then an
+     * {@code IllegalArgumentException} will be thrown to prevent non-deterministic
+     * results.
      *
      * <p>
-     * If the "value" parameter was not specified by this instance, then the
-     * annotation's <code>ClassInfo</code> is checked for a default value.
-     * If there is a default, that value is returned. Otherwise null is
-     * returned.
+     * If the {@code value} member was not specified by this instance, then the
+     * annotation's {@code ClassInfo} is checked for a default value. If there
+     * is a default, that value is returned. Otherwise {@code null} is returned.
      * </p>
      *
      * @param index the index containing the defining annotation class
-     * @return the "value" value, or its default, or null
+     * @return the {@code value} annotation member, or {@code null}
      * @throws IllegalArgumentException if index does not contain the defining
      *         annotation class
      * @since 2.1
@@ -326,19 +323,19 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Returns a list of all parameter values on this annotation instance,
-     * including default values id defined. Since an annotation's defaults are
-     * only stored on the annotation's defining class, and not usages of the
-     * annotation, an index containing the Annotation class must be provided as
-     * a parameter. If the index does not contain the defining annotation class,
-     * then an <code>IllegalArgumentException</code> will be thrown to prevent
-     * non-deterministic results.
+     * Returns a list of all members of this annotation instance, including default
+     * values if defined. Since an annotation's defaults are only stored on the
+     * annotation's defining class, and not usages of the annotation, an index
+     * containing the annotation class must be provided as a parameter. If the index
+     * does not contain the defining annotation class, then an
+     * {@code IllegalArgumentException} will be thrown to prevent non-deterministic
+     * results.
      *
      * <p>
      * The order of this list is undefined.
      * </p>
      *
-     * @return the parameter values of this annotation
+     * @return immutable list of this annotation's members
      * @throws IllegalArgumentException if index does not contain the defining
      *         annotation class
      * @since 2.1
@@ -365,15 +362,15 @@ public final class AnnotationInstance {
     }
 
     /**
-     * Returns a list of all parameter values on this annotation instance.
+     * Returns an immutable list of all members of this annotation instance.
      * While random access is allowed, the ordering algorithm
      * of the list should not be relied upon. Although it will
      * be consistent for the life of this instance.
      *
-     * @return the parameter values of this annotation
+     * @return immutable list of this annotation's members
      */
     public List<AnnotationValue> values() {
-        return Collections.unmodifiableList(Arrays.asList(values));
+        return new ImmutableArrayList<>(values);
     }
 
     AnnotationValue[] valueArray() {

--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -140,7 +140,7 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
          * @return the list of parameters.
          */
         public List<Type> parameters() {
-            return Collections.unmodifiableList(Arrays.asList(parameters));
+            return new ImmutableArrayList<>(parameters);
         }
 
         Type[] parametersArray() {
@@ -958,7 +958,7 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
      * @return immutable list of types declared in the {@code implements} clause of this class
      */
     public final List<Type> interfaceTypes() {
-        return Collections.unmodifiableList(Arrays.asList(interfaceTypes));
+        return new ImmutableArrayList<>(interfaceTypes);
     }
 
     final Type[] interfaceTypeArray() {
@@ -985,9 +985,8 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
      * @return immutable list of generic type parameters of this class
      */
     public final List<TypeVariable> typeParameters() {
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        List<TypeVariable> list = (List) Arrays.asList(typeParameters);
-        return Collections.unmodifiableList(list);
+        // type parameters are always `TypeVariable`
+        return new ImmutableArrayList(typeParameters);
     }
 
     final Type[] typeParameterArray() {

--- a/core/src/main/java/org/jboss/jandex/FieldInternal.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInternal.java
@@ -149,7 +149,7 @@ final class FieldInternal {
     }
 
     final List<AnnotationInstance> annotations() {
-        return Collections.unmodifiableList(Arrays.asList(annotations));
+        return new ImmutableArrayList<>(annotations);
     }
 
     final AnnotationInstance[] annotationArray() {

--- a/core/src/main/java/org/jboss/jandex/ImmutableArrayList.java
+++ b/core/src/main/java/org/jboss/jandex/ImmutableArrayList.java
@@ -1,0 +1,21 @@
+package org.jboss.jandex;
+
+import java.util.AbstractList;
+
+final class ImmutableArrayList<T> extends AbstractList<T> {
+    private final T[] array;
+
+    ImmutableArrayList(T[] array) {
+        this.array = array;
+    }
+
+    @Override
+    public T get(int index) {
+        return array[index];
+    }
+
+    @Override
+    public int size() {
+        return array.length;
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -778,7 +778,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
             return Collections.emptyList();
         }
 
-        return Collections.unmodifiableList(Arrays.asList(annotationInstances));
+        return new ImmutableArrayList<>(annotationInstances);
     }
 
     private void addClassToMap(HashMap<DotName, List<ClassInfo>> map, DotName name, ClassInfo currentClass) {

--- a/core/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -269,11 +269,11 @@ final class MethodInternal {
     }
 
     final List<Type> parameterTypes() {
-        return Collections.unmodifiableList(Arrays.asList(parameterTypes));
+        return new ImmutableArrayList<>(parameterTypes);
     }
 
     final List<Type> descriptorParameterTypes() {
-        return Collections.unmodifiableList(Arrays.asList(descriptorParameterTypes));
+        return new ImmutableArrayList<>(descriptorParameterTypes);
     }
 
     final Type[] descriptorParameterTypesArray() {
@@ -307,7 +307,7 @@ final class MethodInternal {
     }
 
     final List<Type> exceptions() {
-        return Collections.unmodifiableList(Arrays.asList(exceptions));
+        return new ImmutableArrayList<>(exceptions);
     }
 
     final Type[] exceptionArray() {
@@ -315,13 +315,12 @@ final class MethodInternal {
     }
 
     final List<TypeVariable> typeParameters() {
-        @SuppressWarnings("unchecked") // type parameters will always be TypeVariable[]
-        List<TypeVariable> list = (List) Arrays.asList(typeParameters);
-        return Collections.unmodifiableList(list);
+        // type parameters are always `TypeVariable`
+        return new ImmutableArrayList(typeParameters);
     }
 
     final List<AnnotationInstance> annotations() {
-        return Collections.unmodifiableList(Arrays.asList(annotations));
+        return new ImmutableArrayList<>(annotations);
     }
 
     final AnnotationInstance[] annotationArray() {

--- a/core/src/main/java/org/jboss/jandex/ParameterizedType.java
+++ b/core/src/main/java/org/jboss/jandex/ParameterizedType.java
@@ -204,7 +204,7 @@ public class ParameterizedType extends Type {
      * @return the list of type arguments, or empty if none
      */
     public List<Type> arguments() {
-        return Collections.unmodifiableList(Arrays.asList(arguments));
+        return new ImmutableArrayList<>(arguments);
     }
 
     Type[] argumentsArray() {

--- a/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
+++ b/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
@@ -136,7 +136,7 @@ final class RecordComponentInternal {
     }
 
     final List<AnnotationInstance> annotations() {
-        return Collections.unmodifiableList(Arrays.asList(annotations));
+        return new ImmutableArrayList<>(annotations);
     }
 
     final AnnotationInstance[] annotationArray() {

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -441,7 +441,7 @@ public abstract class Type implements Descriptor {
      * @since 2.0
      */
     public List<AnnotationInstance> annotations() {
-        return Collections.unmodifiableList(Arrays.asList(annotations));
+        return new ImmutableArrayList<>(annotations);
     }
 
     Type addAnnotation(AnnotationInstance annotation) {

--- a/core/src/main/java/org/jboss/jandex/TypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariable.java
@@ -122,7 +122,7 @@ public final class TypeVariable extends Type {
     }
 
     public List<Type> bounds() {
-        return Collections.unmodifiableList(Arrays.asList(bounds));
+        return new ImmutableArrayList<>(bounds);
     }
 
     Type[] boundArray() {


### PR DESCRIPTION
This commit replaces `Collections.unmodifiableList(Arrays.asList(array))` with `new ImmutableArrayList<>(array)`, where `ImmutableArrayList` is a simple implementation of an immutable array-backed list. This reduces the number of allocations from 2 to 1 on many places in the code.

Additionally, this commit slightly improves javadoc of some methods in the `AnnotationInstance` class.