### PR TITLE
Avoid having a ton of empty HashMaps in memory

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -654,7 +654,7 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
     }
 
     final void setAnnotations(Map<DotName, List<AnnotationInstance>> annotations) {
-        this.annotations = annotations;
+        this.annotations = Utils.minimize(annotations);
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/Utils.java
+++ b/core/src/main/java/org/jboss/jandex/Utils.java
@@ -61,8 +61,19 @@ class Utils {
         return result;
     }
 
+    static <K, V> Map<K, V> minimize(Map<K, V> map) {
+        if (map.isEmpty()) {
+            return Collections.emptyMap();
+        } else if (map.size() == 1) {
+            Map.Entry<K, V> entry = map.entrySet().iterator().next();
+            return Collections.singletonMap(entry.getKey(), entry.getValue());
+        } else {
+            return map;
+        }
+    }
+
     static <T> List<T> listOfCapacity(int capacity) {
-        return capacity > 0 ? new ArrayList<T>(capacity) : Collections.<T> emptyList();
+        return capacity > 0 ? new ArrayList<>(capacity) : Collections.emptyList();
     }
 
     static final class ReusableBufferedDataInputStream extends DataInputStream {


### PR DESCRIPTION
I'm working on a heap dump and Eclipse MAT complained that there was a lot of empty HashMaps around. I had a closer look and a lot of them were due to the Map kept in ClassInfo and this one looked like the most plausible culprit.
Now, in Quarkus, the Jandex index is just around for building the application but it looks like an easy win.
I also handled the size 1 case but I'm not sure it's worth the hassle as long as we stick to Java 8.

@Ladicek this is not to merge as is, it was more to get your feedback with a concrete explanation. 

The following screenshot is a query of the empty HashMaps in the heap dump.
Note that it's the same in the KeySet entry that is at the top.

![Screenshot from 2024-06-24 15-02-36](https://github.com/smallrye/jandex/assets/1279749/c2e8954a-1bdb-4ea1-95f1-7db8d59e22ba)
