### PR TITLE
Added indexVersion parameter to the jandex-jar goal

### DIFF
--- a/maven-plugin/src/main/java/org/jboss/jandex/maven/JandexJarGoal.java
+++ b/maven-plugin/src/main/java/org/jboss/jandex/maven/JandexJarGoal.java
@@ -40,6 +40,12 @@ public class JandexJarGoal extends AbstractMojo {
     private String indexName;
 
     /**
+     * Persistent index format version to write. Defaults to max supported version.
+     */
+    @Parameter
+    private Integer indexVersion;
+
+    /**
      * Names or glob patterns of files in the JAR that should be indexed.
      */
     @Parameter
@@ -103,7 +109,12 @@ public class JandexJarGoal extends AbstractMojo {
             }
 
             out.putNextEntry(new ZipEntry(indexName));
-            new IndexWriter(out).write(index);
+            IndexWriter writer = new IndexWriter(out);
+            if (indexVersion != null) {
+                writer.write(index, indexVersion);
+            } else {
+                writer.write(index);
+            }
         } catch (IOException e) {
             try {
                 Files.deleteIfExists(tmp);


### PR DESCRIPTION
If you're happy with this change to add the indexVersion parameter to the jandex-jar goal (it's already present in the jandex goal), then it would be appreciated if you could apply this change to the base repository either via this pull request, or independently.