### PR TITLE
Various improvements to the release process

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,7 +1,5 @@
 name: Jandex Prepare Release
 
-run-name: Prepare ${{github.event.inputs.tag || github.ref_name}} Release
-
 on:
   pull_request:
     types:
@@ -29,6 +27,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
 
     - name: Before release
       run: |
@@ -49,6 +49,8 @@ jobs:
 
     uses: smallrye/.github/.github/workflows/prepare-release.yml@main
     secrets: inherit
+    with:
+      checkout-git-ref: true
 
   after-release:
     name: After release
@@ -66,6 +68,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
 
     - name: After release
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Jandex Release
 
-run-name: Perform ${{github.event.inputs.tag || github.ref_name}} Release
+run-name: Release ${{github.event.inputs.tag || github.ref_name}}
 
 on:
   push:
@@ -32,35 +32,4 @@ jobs:
   github-pages:
     name: GitHub Pages
     needs: perform-release
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: gh-pages
-
-    - name: Set up Node.js 16
-      uses: actions/setup-node@v4
-      with:
-        node-version: 16
-
-    - name: Generate and push
-      run: |
-        node --version
-
-        curl -s -L -o antora-playbook.yml https://github.com/smallrye/jandex/blob/main/doc/antora-playbook-prod.yml?raw=true
-
-        npm install @antora/cli@3.0 @antora/site-generator-default@3.0
-        npx antora generate antora-playbook.yml
-
-        rm -rf node_modules docs package.json package-lock.json antora-playbook.yml
-        mv -T build/site docs
-        touch docs/.nojekyll
-
-        git config --global user.name "SmallRye CI"
-        git config --global user.email "smallrye@googlegroups.com"
-        git status
-        git add -A .
-        git commit -m 'Generate documentation site'
-        git push
+    uses: ./.github/workflows/pages.yml

--- a/.github/workflows/review-release.yml
+++ b/.github/workflows/review-release.yml
@@ -1,7 +1,5 @@
 name: Jandex Review Release
 
-run-name: Review ${{github.event.inputs.tag || github.ref_name}} Release
-
 on:
   pull_request:
     paths:


### PR DESCRIPTION
- checkout the originating git ref instead of the exact commit
- reuse the `pages.yml` workflow instead of copying it
- remove two useless `run-name` configurations