### PR TITLE
Add JandexReflection.loadType()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/JandexReflection.java
+++ b/core/src/main/java/org/jboss/jandex/JandexReflection.java
@@ -1,11 +1,499 @@
 package org.jboss.jandex;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
 /**
  * Utilities that allow moving from the Jandex world to the runtime world using reflection.
  * To maintain stratification, these methods are intentionally <em>not</em> present
  * on the respective Jandex classes.
  */
 public class JandexReflection {
+    /**
+     * An implementation of {@link java.lang.reflect.GenericArrayType} that is compatible with the JDK's implementation
+     * (as in, the {@code equals()} and {@code hashCode()} methods work as expected).
+     */
+    private static class GenericArrayTypeImpl implements java.lang.reflect.GenericArrayType {
+        private final java.lang.reflect.Type genericComponentType;
+
+        GenericArrayTypeImpl(java.lang.reflect.Type genericComponentType) {
+            this.genericComponentType = genericComponentType;
+        }
+
+        @Override
+        public java.lang.reflect.Type getGenericComponentType() {
+            return genericComponentType;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj instanceof java.lang.reflect.GenericArrayType) {
+                java.lang.reflect.GenericArrayType that = (java.lang.reflect.GenericArrayType) obj;
+                return Objects.equals(genericComponentType, that.getGenericComponentType());
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(genericComponentType);
+        }
+
+        @Override
+        public String toString() {
+            return genericComponentType + "[]";
+        }
+    }
+
+    /**
+     * An implementation of {@link java.lang.reflect.ParameterizedType} that is compatible with the JDK's implementation
+     * (as in, the {@code equals()} and {@code hashCode()} methods work as expected).
+     */
+    private static class ParameterizedTypeImpl implements java.lang.reflect.ParameterizedType {
+        private final java.lang.reflect.Type ownerType;
+        private final java.lang.reflect.Type rawType;
+        private final java.lang.reflect.Type[] actualTypeArguments;
+
+        ParameterizedTypeImpl(java.lang.reflect.Type rawType, java.lang.reflect.Type[] actualTypeArguments,
+                java.lang.reflect.Type ownerType) {
+            this.ownerType = ownerType;
+            this.rawType = rawType;
+            this.actualTypeArguments = actualTypeArguments;
+        }
+
+        @Override
+        public java.lang.reflect.Type[] getActualTypeArguments() {
+            return Arrays.copyOf(actualTypeArguments, actualTypeArguments.length);
+        }
+
+        @Override
+        public java.lang.reflect.Type getOwnerType() {
+            return ownerType;
+        }
+
+        @Override
+        public java.lang.reflect.Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj instanceof java.lang.reflect.ParameterizedType) {
+                java.lang.reflect.ParameterizedType that = (java.lang.reflect.ParameterizedType) obj;
+                return Objects.equals(ownerType, that.getOwnerType())
+                        && Objects.equals(rawType, that.getRawType())
+                        && Arrays.equals(actualTypeArguments, that.getActualTypeArguments());
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(actualTypeArguments)
+                    ^ Objects.hashCode(ownerType)
+                    ^ Objects.hashCode(rawType);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder();
+            result.append(rawType.getTypeName());
+            StringJoiner joiner = new StringJoiner(", ", "<", ">");
+            joiner.setEmptyValue("");
+            for (java.lang.reflect.Type typeArgument : actualTypeArguments) {
+                joiner.add(typeArgument.getTypeName());
+            }
+            result.append(joiner);
+            return result.toString();
+        }
+    }
+
+    /**
+     * An implementation of {@link java.lang.reflect.TypeVariable} that is <strong>NOT</strong> compatible with
+     * the JDK's implementation (as in, the {@code equals()} and {@code hashCode()} methods <em>do not</em> work
+     * as expected).
+     */
+    private static class TypeVariableImpl<D extends java.lang.reflect.GenericDeclaration>
+            implements java.lang.reflect.TypeVariable<D> {
+        private final String name;
+        private final java.lang.reflect.Type[] bounds;
+
+        TypeVariableImpl(String name, java.lang.reflect.Type... bounds) {
+            this.name = name;
+            this.bounds = bounds;
+        }
+
+        @Override
+        public java.lang.reflect.Type[] getBounds() {
+            return Arrays.copyOf(bounds, bounds.length);
+        }
+
+        @Override
+        public D getGenericDeclaration() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public java.lang.reflect.AnnotatedType[] getAnnotatedBounds() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Annotation[] getAnnotations() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Annotation[] getDeclaredAnnotations() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            // note that the JDK does not make it possible to implement a compatible `equals()`,
+            // because it checks a specific implementation class in its `equals()`
+            if (this == obj) {
+                return true;
+            } else if (obj instanceof java.lang.reflect.TypeVariable) {
+                java.lang.reflect.TypeVariable<?> that = (java.lang.reflect.TypeVariable<?>) obj;
+                return Objects.equals(name, that.getName()) && Arrays.equals(bounds, that.getBounds());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            // this `hashCode()` is not compatible with the JDK, but that doesn't really matter,
+            // because it's not possible to implement a compatible `equals()` anyway
+            return Objects.hash(name, Arrays.hashCode(bounds));
+        }
+
+        @Override
+        public String toString() {
+            StringJoiner joiner = new StringJoiner(" & ", " extends ", "");
+            joiner.setEmptyValue("");
+            for (java.lang.reflect.Type bound : bounds) {
+                if (bound instanceof Class) {
+                    joiner.add(((Class<?>) bound).getName());
+                } else {
+                    joiner.add(bound.toString());
+                }
+            }
+            return name + joiner;
+        }
+    }
+
+    /**
+     * A delegating implementation of {@link java.lang.reflect.TypeVariable} that is <strong>NOT</strong> compatible
+     * with the JDK's implementation (as in, the {@code equals()} and {@code hashCode()} methods <em>do not</em> work
+     * as expected).
+     * <p>
+     * The delegate is expected to be set <em>after</em> construction using {@link #setDelegate(TypeVariableImpl)}.
+     * It is useful to represent recursive type variables.
+     */
+    private static class TypeVariableReferenceImpl<D extends java.lang.reflect.GenericDeclaration>
+            implements java.lang.reflect.TypeVariable<D> {
+        private TypeVariableImpl<D> delegate;
+
+        void setDelegate(TypeVariableImpl<D> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public java.lang.reflect.Type[] getBounds() {
+            return delegate.getBounds();
+        }
+
+        @Override
+        public D getGenericDeclaration() {
+            return delegate.getGenericDeclaration();
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public java.lang.reflect.AnnotatedType[] getAnnotatedBounds() {
+            return delegate.getAnnotatedBounds();
+        }
+
+        @Override
+        public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+            return delegate.getAnnotation(annotationClass);
+        }
+
+        @Override
+        public Annotation[] getAnnotations() {
+            return delegate.getAnnotations();
+        }
+
+        @Override
+        public Annotation[] getDeclaredAnnotations() {
+            return delegate.getDeclaredAnnotations();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return delegate.equals(o);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+
+    /**
+     * An implementation of {@link java.lang.reflect.WildcardType} that is compatible with the JDK's implementation
+     * (as in, the {@code equals()} and {@code hashCode()} methods work as expected).
+     */
+    private static class WildcardTypeImpl implements java.lang.reflect.WildcardType {
+        private static final java.lang.reflect.Type[] DEFAULT_UPPER_BOUND = new java.lang.reflect.Type[] { Object.class };
+        private static final java.lang.reflect.Type[] DEFAULT_LOWER_BOUND = new java.lang.reflect.Type[0];
+        private static final java.lang.reflect.WildcardType UNBOUNDED = new WildcardTypeImpl(DEFAULT_UPPER_BOUND,
+                DEFAULT_LOWER_BOUND);
+
+        static java.lang.reflect.WildcardType unbounded() {
+            return UNBOUNDED;
+        }
+
+        static java.lang.reflect.WildcardType withUpperBound(java.lang.reflect.Type type) {
+            return new WildcardTypeImpl(new java.lang.reflect.Type[] { type }, DEFAULT_LOWER_BOUND);
+        }
+
+        static java.lang.reflect.WildcardType withLowerBound(java.lang.reflect.Type type) {
+            return new WildcardTypeImpl(DEFAULT_UPPER_BOUND, new java.lang.reflect.Type[] { type });
+        }
+
+        private final java.lang.reflect.Type[] upperBound;
+        private final java.lang.reflect.Type[] lowerBound;
+
+        private WildcardTypeImpl(java.lang.reflect.Type[] upperBound, java.lang.reflect.Type[] lowerBound) {
+            this.upperBound = upperBound;
+            this.lowerBound = lowerBound;
+        }
+
+        @Override
+        public java.lang.reflect.Type[] getUpperBounds() {
+            return upperBound;
+        }
+
+        @Override
+        public java.lang.reflect.Type[] getLowerBounds() {
+            return lowerBound;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj instanceof java.lang.reflect.WildcardType) {
+                java.lang.reflect.WildcardType that = (java.lang.reflect.WildcardType) obj;
+                return Arrays.equals(lowerBound, that.getLowerBounds())
+                        && Arrays.equals(upperBound, that.getUpperBounds());
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(lowerBound) ^ Arrays.hashCode(upperBound);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder("?");
+            if (upperBound.length > 0 && !upperBound[0].equals(Object.class)) {
+                result.append(" extends ").append(upperBound[0]);
+            } else if (lowerBound.length > 0) {
+                result.append(" super ").append(lowerBound[0]);
+            }
+            return result.toString();
+        }
+    }
+
+    private static class TypeVariables {
+        private Map<String, TypeVariableImpl<?>> typeVariables;
+        private Map<String, TypeVariableReferenceImpl<?>> typeVariableReferences;
+
+        TypeVariableImpl<?> getTypeVariable(String identifier) {
+            return typeVariables != null ? typeVariables.get(identifier) : null;
+        }
+
+        void setTypeVariable(String identifier, TypeVariableImpl<?> typeVariable) {
+            if (typeVariables == null) {
+                typeVariables = new HashMap<>();
+            }
+            typeVariables.put(identifier, typeVariable);
+        }
+
+        TypeVariableReferenceImpl<?> getTypeVariableReference(String identifier) {
+            return typeVariableReferences != null ? typeVariableReferences.get(identifier) : null;
+        }
+
+        void setTypeVariableReference(String identifier, TypeVariableReferenceImpl<?> typeVariableReference) {
+            if (typeVariableReferences == null) {
+                typeVariableReferences = new HashMap<>();
+            }
+            typeVariableReferences.put(identifier, typeVariableReference);
+        }
+
+        void patchReferences() {
+            if (typeVariableReferences == null) {
+                return;
+            }
+            typeVariableReferences.forEach((identifier, reference) -> {
+                TypeVariableImpl<?> typeVar = typeVariables.get(identifier);
+                if (typeVar != null) {
+                    reference.setDelegate((TypeVariableImpl) typeVar);
+                }
+            });
+        }
+    }
+
+    /**
+     * Loads a Reflection {@link java.lang.reflect.Type Type} corresponding to the given Jandex {@link Type}.
+     * Classes are loaded from the thread context classloader. If there is no TCCL, the classloader
+     * that loaded {@code JandexReflection} is used. Returns {@code null} when {@code type} is {@code null}.
+     * <p>
+     * The result is {@linkplain Object#equals(Object) equal} to the corresponding {@code Type} obtained
+     * from Reflection and has the same {@linkplain Object#hashCode() hash code}, as long as it doesn't
+     * contain any type variables.
+     *
+     * @param type a Jandex {@link Type}
+     * @return the corresponding Reflection {@link java.lang.reflect.Type Type}
+     */
+    public static java.lang.reflect.Type loadType(Type type) {
+        TypeVariables typeVariables = new TypeVariables();
+        java.lang.reflect.Type result = loadType(type, typeVariables);
+        typeVariables.patchReferences();
+        return result;
+    }
+
+    private static java.lang.reflect.Type loadType(Type type, TypeVariables typeVariables) {
+        if (type == null) {
+            return null;
+        }
+
+        switch (type.kind()) {
+            case VOID:
+                return void.class;
+            case PRIMITIVE:
+                switch (type.asPrimitiveType().primitive()) {
+                    case BOOLEAN:
+                        return boolean.class;
+                    case BYTE:
+                        return byte.class;
+                    case SHORT:
+                        return short.class;
+                    case INT:
+                        return int.class;
+                    case LONG:
+                        return long.class;
+                    case FLOAT:
+                        return float.class;
+                    case DOUBLE:
+                        return double.class;
+                    case CHAR:
+                        return char.class;
+                    default:
+                        throw new IllegalArgumentException("Unknown primitive type: " + type);
+                }
+            case CLASS:
+                return load(type.name());
+            case PARAMETERIZED_TYPE:
+                java.lang.reflect.Type ownerType = null;
+                if (type.asParameterizedType().owner() != null) {
+                    // the `owner()` does not always correspond to the JDK's owner,
+                    // but there's nothing we can do about that here
+                    ownerType = loadType(type.asParameterizedType().owner(), typeVariables);
+                }
+                java.lang.reflect.Type rawType = load(type.name());
+                Type[] typeArguments = type.asParameterizedType().argumentsArray();
+                java.lang.reflect.Type[] typeArgumentsReflective = new java.lang.reflect.Type[typeArguments.length];
+                for (int i = 0; i < typeArguments.length; i++) {
+                    typeArgumentsReflective[i] = loadType(typeArguments[i], typeVariables);
+                }
+                return new ParameterizedTypeImpl(rawType, typeArgumentsReflective, ownerType);
+            case ARRAY:
+                Type.Kind elementTypeKind = type.asArrayType().elementType().kind();
+                if (elementTypeKind == Type.Kind.PRIMITIVE || elementTypeKind == Type.Kind.CLASS) {
+                    return load(type.name());
+                }
+                java.lang.reflect.Type componentType = loadType(type.asArrayType().componentType(), typeVariables);
+                return new GenericArrayTypeImpl(componentType);
+            case WILDCARD_TYPE:
+                if (type.asWildcardType().hasImplicitObjectBound()) {
+                    return WildcardTypeImpl.unbounded();
+                }
+                java.lang.reflect.Type bound = loadType(type.asWildcardType().bound(), typeVariables);
+                if (type.asWildcardType().isExtends()) {
+                    return WildcardTypeImpl.withUpperBound(bound);
+                } else {
+                    return WildcardTypeImpl.withLowerBound(bound);
+                }
+            case TYPE_VARIABLE:
+                String tvIdentifier = type.asTypeVariable().identifier();
+                TypeVariableImpl<?> typeVariable = typeVariables.getTypeVariable(tvIdentifier);
+                if (typeVariable == null) {
+                    Type[] bounds = type.asTypeVariable().boundArray();
+                    java.lang.reflect.Type[] boundsReflective = new java.lang.reflect.Type[bounds.length];
+                    for (int i = 0; i < bounds.length; i++) {
+                        boundsReflective[i] = loadType(bounds[i], typeVariables);
+                    }
+                    typeVariable = new TypeVariableImpl<>(tvIdentifier, boundsReflective);
+                    typeVariables.setTypeVariable(tvIdentifier, typeVariable);
+                }
+                return typeVariable;
+            case TYPE_VARIABLE_REFERENCE:
+                String tvrIdentifier = type.asTypeVariableReference().identifier();
+                TypeVariableReferenceImpl<?> typeVariableReference = typeVariables.getTypeVariableReference(tvrIdentifier);
+                if (typeVariableReference == null) {
+                    typeVariableReference = new TypeVariableReferenceImpl<>();
+                    typeVariables.setTypeVariableReference(tvrIdentifier, typeVariableReference);
+                }
+                return typeVariableReference;
+            case UNRESOLVED_TYPE_VARIABLE:
+                String utvIdentifier = type.asUnresolvedTypeVariable().identifier();
+                TypeVariableImpl<?> unresolvedTypeVariable = typeVariables.getTypeVariable(utvIdentifier);
+                if (unresolvedTypeVariable == null) {
+                    unresolvedTypeVariable = new TypeVariableImpl<>(utvIdentifier);
+                    typeVariables.setTypeVariable(utvIdentifier, unresolvedTypeVariable);
+                }
+                return unresolvedTypeVariable;
+            default:
+                throw new IllegalArgumentException("Unknown type: " + type);
+        }
+    }
+
     /**
      * Loads a class corresponding to the raw type of given {@link Type} from the thread context classloader.
      * If there is no TCCL, the classloader that loaded {@code JandexReflection} is used.

--- a/core/src/test/java/org/jboss/jandex/test/JandexReflectionTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/JandexReflectionTest.java
@@ -1,10 +1,12 @@
 package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
@@ -25,6 +27,8 @@ public class JandexReflectionTest {
         List<String> parameterized();
 
         String[][] array();
+
+        List<? extends Number>[] genericArray();
 
         // annotations are present to make sure the `ArrayType` has multiple levels of nesting
         @MyAnnotation("1")
@@ -60,49 +64,203 @@ public class JandexReflectionTest {
         }
     }
 
-    static class SimpleClass {
+    @Test
+    public void loadType() throws IOException {
+        // intentionally _not_ indexing `NestedClass`, so that the type parameter bound of `InnerClass` is unresolved
+        Index index = Index.of(TestMethods.class, NestedClass.InnerClass.class);
+
+        ClassInfo clazz = index.getClassByName(TestMethods.class);
+        assertEquals(typeReflective(clazz, "nothing"), type(clazz, "nothing"));
+        assertEquals(typeReflective(clazz, "primitive"), type(clazz, "primitive"));
+        assertEquals(typeReflective(clazz, "clazz"), type(clazz, "clazz"));
+        assertEquals(typeReflective(clazz, "parameterized"), type(clazz, "parameterized"));
+        assertEquals(typeReflective(clazz, "array"), type(clazz, "array"));
+        assertEquals(typeReflective(clazz, "genericArray"), type(clazz, "genericArray"));
+        assertEquals(typeReflective(clazz, "annotatedArray"), type(clazz, "annotatedArray"));
+        assertTypeVariable(type(clazz, "typeParameter"), tv -> {
+            assertEquals("X", tv.getName());
+            assertEquals(1, tv.getBounds().length);
+            assertEquals(Object.class, tv.getBounds()[0]);
+        });
+        assertTypeVariable(type(clazz, "typeParameterWithSingleBound"), tv -> {
+            assertEquals("Y", tv.getName());
+            assertEquals(1, tv.getBounds().length);
+            assertEquals(Number.class, tv.getBounds()[0]);
+        });
+        assertTypeVariable(type(clazz, "typeParameterWithMultipleBounds"), tv -> {
+            assertEquals("Y", tv.getName());
+            assertEquals(2, tv.getBounds().length);
+            assertEquals(Number.class, tv.getBounds()[0]);
+            assertInstanceOf(java.lang.reflect.ParameterizedType.class, tv.getBounds()[1]);
+            java.lang.reflect.ParameterizedType bound = (java.lang.reflect.ParameterizedType) tv.getBounds()[1];
+            assertEquals(Comparable.class, bound.getRawType());
+            assertEquals(1, bound.getActualTypeArguments().length);
+            assertInstanceOf(java.lang.reflect.TypeVariable.class, bound.getActualTypeArguments()[0]);
+            assertEquals("Y", ((java.lang.reflect.TypeVariable<?>) bound.getActualTypeArguments()[0]).getName());
+        });
+        assertTypeVariable(type(clazz, "typeParameterWithSingleParameterizedBound"), tv -> {
+            assertEquals("Y", tv.getName());
+            assertEquals(1, tv.getBounds().length);
+            assertInstanceOf(java.lang.reflect.ParameterizedType.class, tv.getBounds()[0]);
+            java.lang.reflect.ParameterizedType bound = (java.lang.reflect.ParameterizedType) tv.getBounds()[0];
+            assertEquals(Comparable.class, bound.getRawType());
+            assertEquals(1, bound.getActualTypeArguments().length);
+            assertInstanceOf(java.lang.reflect.TypeVariable.class, bound.getActualTypeArguments()[0]);
+            assertEquals("Y", ((java.lang.reflect.TypeVariable<?>) bound.getActualTypeArguments()[0]).getName());
+        });
+        assertTypeVariable(type(clazz, "typeParameterWithMultipleBoundsFirstParameterized"), tv -> {
+            assertEquals("Y", tv.getName());
+            assertEquals(2, tv.getBounds().length);
+            assertInstanceOf(java.lang.reflect.ParameterizedType.class, tv.getBounds()[0]);
+            java.lang.reflect.ParameterizedType bound = (java.lang.reflect.ParameterizedType) tv.getBounds()[0];
+            assertEquals(Comparable.class, bound.getRawType());
+            assertEquals(1, bound.getActualTypeArguments().length);
+            assertInstanceOf(java.lang.reflect.TypeVariable.class, bound.getActualTypeArguments()[0]);
+            assertEquals("Y", ((java.lang.reflect.TypeVariable<?>) bound.getActualTypeArguments()[0]).getName());
+            assertEquals(Serializable.class, tv.getBounds()[1]);
+        });
+        assertTypeVariable(type(clazz, "typeParameterWithMultipleBoundsSecondParameterized"), tv -> {
+            assertEquals("Y", tv.getName());
+            assertEquals(2, tv.getBounds().length);
+            assertEquals(Serializable.class, tv.getBounds()[0]);
+            assertInstanceOf(java.lang.reflect.ParameterizedType.class, tv.getBounds()[1]);
+            java.lang.reflect.ParameterizedType bound = (java.lang.reflect.ParameterizedType) tv.getBounds()[1];
+            assertEquals(Comparable.class, bound.getRawType());
+            assertEquals(1, bound.getActualTypeArguments().length);
+            assertInstanceOf(java.lang.reflect.TypeVariable.class, bound.getActualTypeArguments()[0]);
+            assertEquals("Y", ((java.lang.reflect.TypeVariable<?>) bound.getActualTypeArguments()[0]).getName());
+        });
+        assertEquals(firstTypeArgumentReflective(clazz, "unboundedWildcard"), firstTypeArgument(clazz, "unboundedWildcard"));
+        assertEquals(firstTypeArgumentReflective(clazz, "wildcardWithUpperBound"),
+                firstTypeArgument(clazz, "wildcardWithUpperBound"));
+        assertEquals(firstTypeArgumentReflective(clazz, "wildcardWithLowerBound"),
+                firstTypeArgument(clazz, "wildcardWithLowerBound"));
+        assertWildcardType(firstTypeArgument(clazz, "wildcardWithUnboundedTypeParameterAsUpperBound"), wt -> {
+            assertEquals(1, wt.getUpperBounds().length);
+            assertTypeVariable(wt.getUpperBounds()[0], tv -> {
+                assertEquals("X", tv.getName());
+                assertEquals(1, tv.getBounds().length);
+                assertEquals(Object.class, tv.getBounds()[0]);
+            });
+            assertEquals(0, wt.getLowerBounds().length);
+        });
+        assertWildcardType(firstTypeArgument(clazz, "wildcardWithBoundedTypeParameterAsUpperBound"), wt -> {
+            assertEquals(1, wt.getUpperBounds().length);
+            assertTypeVariable(wt.getUpperBounds()[0], tv -> {
+                assertEquals("Y", tv.getName());
+                assertEquals(1, tv.getBounds().length);
+                assertEquals(Number.class, tv.getBounds()[0]);
+            });
+            assertEquals(0, wt.getLowerBounds().length);
+        });
+        assertWildcardType(firstTypeArgument(clazz, "wildcardWithBoundedTypeParameterAsLowerBound"), wt -> {
+            assertEquals(1, wt.getUpperBounds().length);
+            assertEquals(Object.class, wt.getUpperBounds()[0]);
+            assertEquals(1, wt.getLowerBounds().length);
+            assertTypeVariable(wt.getLowerBounds()[0], tv -> {
+                assertEquals("Y", tv.getName());
+                assertEquals(1, tv.getBounds().length);
+                assertEquals(Number.class, tv.getBounds()[0]);
+            });
+        });
+
+        TypeVariable u = index.getClassByName(NestedClass.InnerClass.class).typeParameters().get(0);
+        java.lang.reflect.Type uReflective = JandexReflection.loadType(u);
+        assertInstanceOf(java.lang.reflect.TypeVariable.class, uReflective);
+        assertEquals("U", ((java.lang.reflect.TypeVariable<?>) uReflective).getName());
+        assertEquals(1, ((java.lang.reflect.TypeVariable<?>) uReflective).getBounds().length);
+
+        assertEquals(Type.Kind.UNRESOLVED_TYPE_VARIABLE, u.bounds().get(0).kind());
+        UnresolvedTypeVariable t = u.bounds().get(0).asUnresolvedTypeVariable();
+        java.lang.reflect.Type tReflective = JandexReflection.loadType(t);
+        assertInstanceOf(java.lang.reflect.TypeVariable.class, tReflective);
+        assertEquals("T", ((java.lang.reflect.TypeVariable<?>) tReflective).getName());
+        assertEquals(0, ((java.lang.reflect.TypeVariable<?>) tReflective).getBounds().length);
+    }
+
+    private void assertTypeVariable(java.lang.reflect.Type type, Consumer<java.lang.reflect.TypeVariable<?>> assertion) {
+        assertInstanceOf(java.lang.reflect.TypeVariable.class, type);
+        assertion.accept((java.lang.reflect.TypeVariable<?>) type);
+    }
+
+    private void assertWildcardType(java.lang.reflect.Type type, Consumer<java.lang.reflect.WildcardType> assertion) {
+        assertInstanceOf(java.lang.reflect.WildcardType.class, type);
+        assertion.accept((java.lang.reflect.WildcardType) type);
+    }
+
+    private java.lang.reflect.Type type(ClassInfo clazz, String method) {
+        Type jandexType = clazz.firstMethod(method).returnType();
+        return JandexReflection.loadType(jandexType);
+    }
+
+    private java.lang.reflect.Type typeReflective(ClassInfo clazz, String method) {
+        Class<?> classReflective = JandexReflection.loadClass(clazz);
+        for (java.lang.reflect.Method m : classReflective.getDeclaredMethods()) {
+            if (method.equals(m.getName())) {
+                return m.getGenericReturnType();
+            }
+        }
+        throw new IllegalArgumentException(clazz + " does not have method '" + method + "()'");
+    }
+
+    private java.lang.reflect.Type firstTypeArgument(ClassInfo clazz, String method) {
+        Type jandexType = clazz.firstMethod(method).returnType().asParameterizedType().arguments().get(0);
+        return JandexReflection.loadType(jandexType);
+    }
+
+    private java.lang.reflect.Type firstTypeArgumentReflective(ClassInfo clazz, String method) {
+        java.lang.reflect.Type methodType = typeReflective(clazz, method);
+        return ((java.lang.reflect.ParameterizedType) methodType).getActualTypeArguments()[0];
     }
 
     @Test
-    public void test() throws IOException {
+    public void loadRawType() throws IOException {
         // intentionally _not_ indexing `NestedClass`, so that the type parameter bound of `InnerClass` is unresolved
-        Index index = Index.of(TestMethods.class, NestedClass.InnerClass.class, SimpleClass.class);
+        Index index = Index.of(TestMethods.class, NestedClass.InnerClass.class);
 
         ClassInfo clazz = index.getClassByName(TestMethods.class);
-        assertEquals(void.class, type(clazz, "nothing"));
-        assertEquals(int.class, type(clazz, "primitive"));
-        assertEquals(String.class, type(clazz, "clazz"));
-        assertEquals(List.class, type(clazz, "parameterized"));
-        assertEquals(String[][].class, type(clazz, "array"));
-        assertEquals(String[][][][].class, type(clazz, "annotatedArray"));
-        assertEquals(Object.class, type(clazz, "typeParameter"));
-        assertEquals(Number.class, type(clazz, "typeParameterWithSingleBound"));
-        assertEquals(Number.class, type(clazz, "typeParameterWithMultipleBounds"));
-        assertEquals(Comparable.class, type(clazz, "typeParameterWithSingleParameterizedBound"));
-        assertEquals(Comparable.class, type(clazz, "typeParameterWithMultipleBoundsFirstParameterized"));
-        assertEquals(Serializable.class, type(clazz, "typeParameterWithMultipleBoundsSecondParameterized"));
-        assertEquals(Object.class, firstTypeArgument(clazz, "unboundedWildcard"));
-        assertEquals(Number.class, firstTypeArgument(clazz, "wildcardWithUpperBound"));
-        assertEquals(Object.class, firstTypeArgument(clazz, "wildcardWithLowerBound"));
-        assertEquals(Object.class, firstTypeArgument(clazz, "wildcardWithUnboundedTypeParameterAsUpperBound"));
-        assertEquals(Number.class, firstTypeArgument(clazz, "wildcardWithBoundedTypeParameterAsUpperBound"));
-        assertEquals(Object.class, firstTypeArgument(clazz, "wildcardWithBoundedTypeParameterAsLowerBound"));
+        assertEquals(void.class, rawType(clazz, "nothing"));
+        assertEquals(int.class, rawType(clazz, "primitive"));
+        assertEquals(String.class, rawType(clazz, "clazz"));
+        assertEquals(List.class, rawType(clazz, "parameterized"));
+        assertEquals(String[][].class, rawType(clazz, "array"));
+        assertEquals(List[].class, rawType(clazz, "genericArray"));
+        assertEquals(String[][][][].class, rawType(clazz, "annotatedArray"));
+        assertEquals(Object.class, rawType(clazz, "typeParameter"));
+        assertEquals(Number.class, rawType(clazz, "typeParameterWithSingleBound"));
+        assertEquals(Number.class, rawType(clazz, "typeParameterWithMultipleBounds"));
+        assertEquals(Comparable.class, rawType(clazz, "typeParameterWithSingleParameterizedBound"));
+        assertEquals(Comparable.class, rawType(clazz, "typeParameterWithMultipleBoundsFirstParameterized"));
+        assertEquals(Serializable.class, rawType(clazz, "typeParameterWithMultipleBoundsSecondParameterized"));
+        assertEquals(Object.class, firstRawTypeArgument(clazz, "unboundedWildcard"));
+        assertEquals(Number.class, firstRawTypeArgument(clazz, "wildcardWithUpperBound"));
+        assertEquals(Object.class, firstRawTypeArgument(clazz, "wildcardWithLowerBound"));
+        assertEquals(Object.class, firstRawTypeArgument(clazz, "wildcardWithUnboundedTypeParameterAsUpperBound"));
+        assertEquals(Number.class, firstRawTypeArgument(clazz, "wildcardWithBoundedTypeParameterAsUpperBound"));
+        assertEquals(Object.class, firstRawTypeArgument(clazz, "wildcardWithBoundedTypeParameterAsLowerBound"));
 
         TypeVariable u = index.getClassByName(NestedClass.InnerClass.class).typeParameters().get(0);
+        assertEquals(Object.class, JandexReflection.loadRawType(u));
+
         assertEquals(Type.Kind.UNRESOLVED_TYPE_VARIABLE, u.bounds().get(0).kind());
         UnresolvedTypeVariable t = u.bounds().get(0).asUnresolvedTypeVariable();
         assertEquals(Object.class, JandexReflection.loadRawType(t));
-
-        assertEquals(SimpleClass.class, JandexReflection.loadClass(index.getClassByName(SimpleClass.class)));
     }
 
-    private Class<?> type(ClassInfo clazz, String method) {
+    private Class<?> rawType(ClassInfo clazz, String method) {
         Type jandexType = clazz.firstMethod(method).returnType();
         return JandexReflection.loadRawType(jandexType);
     }
 
-    private Class<?> firstTypeArgument(ClassInfo clazz, String method) {
+    private Class<?> firstRawTypeArgument(ClassInfo clazz, String method) {
         Type jandexType = clazz.firstMethod(method).returnType().asParameterizedType().arguments().get(0);
         return JandexReflection.loadRawType(jandexType);
+    }
+
+    @Test
+    public void loadClass() throws IOException {
+        Index index = Index.of(JandexReflectionTest.class);
+
+        assertEquals(JandexReflectionTest.class, JandexReflection.loadClass(index.getClassByName(JandexReflectionTest.class)));
     }
 }


### PR DESCRIPTION
The `loadType()` method returns an implementation of `java.lang.reflect.Type`.
If possible, it is compatible with the JDK implementation, in the sense that
`equals()` and `hashCode()` work as expected. Unfortunately, the JDK makes
that impossible if the type contains type variables.