### PR TITLE
fix ClassInfo.canonicalRecordConstructor()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ArrayType.java
+++ b/core/src/main/java/org/jboss/jandex/ArrayType.java
@@ -241,6 +241,11 @@ public final class ArrayType extends Type {
         return new ArrayType(constituent, dimensions, newAnnotations);
     }
 
+    @Override
+    Type withoutAnnotations() {
+        return new ArrayType(constituent.withoutAnnotations(), dimensions, null);
+    }
+
     Type copyType(Type component, int dimensions) {
         return new ArrayType(component, dimensions, annotationArray());
     }

--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -772,7 +772,7 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
         RecordComponentInternal[] recordComponents = recordComponentArray();
         byte[] recordComponentPositions = recordComponentPositionArray();
 
-        if (recordComponents.length == recordComponentPositions.length) {
+        if (recordComponents.length == recordComponentPositions.length || recordComponents.length == 1) {
             outer: for (MethodInternal method : methods) {
                 if (!Arrays.equals(Utils.INIT_METHOD_NAME, method.nameBytes())) {
                     // not a constructor
@@ -785,10 +785,24 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
                     continue;
                 }
 
-                for (int i = 0; i < parameters.length; i++) {
-                    if (!parameters[i].equals(recordComponents[recordComponentPositions[i] & 0xFF].type())) {
+                if (parameters.length == 0) {
+                    // immediately OK
+                } else if (parameters.length == 1) {
+                    // we don't store record component positions in case there's just 1, so we need this special case
+                    Type parameter = parameters[0].withoutAnnotations();
+                    Type recordComponent = recordComponents[0].type().withoutAnnotations();
+                    if (!parameter.equals(recordComponent)) {
                         // not a constructor with matching parameter types
                         continue outer;
+                    }
+                } else {
+                    for (int i = 0; i < parameters.length; i++) {
+                        Type parameter = parameters[i].withoutAnnotations();
+                        Type recordComponent = recordComponents[recordComponentPositions[i] & 0xFF].type().withoutAnnotations();
+                        if (!parameter.equals(recordComponent)) {
+                            // not a constructor with matching parameter types
+                            continue outer;
+                        }
                     }
                 }
 

--- a/core/src/main/java/org/jboss/jandex/ParameterizedType.java
+++ b/core/src/main/java/org/jboss/jandex/ParameterizedType.java
@@ -249,6 +249,15 @@ public class ParameterizedType extends Type {
         return new ParameterizedType(name(), arguments, owner, newAnnotations);
     }
 
+    @Override
+    Type withoutAnnotations() {
+        Type[] newArguments = new Type[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            newArguments[i] = arguments[i].withoutAnnotations();
+        }
+        return new ParameterizedType(name(), newArguments, owner, null);
+    }
+
     ParameterizedType copyType(Type[] arguments) {
         return new ParameterizedType(name(), arguments, owner, annotationArray());
     }

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -536,6 +536,17 @@ public abstract class Type implements Descriptor {
     abstract Type copyType(AnnotationInstance[] newAnnotations);
 
     /**
+     * Returns this type with all type annotations removed. The annotations are removed deeply,
+     * that is also on the constituent type in case of arrays, on type arguments in case
+     * of parameterized types, on the bound in case of wildcard types, etc.
+     *
+     * @return this type without type annotations
+     */
+    Type withoutAnnotations() {
+        return copyType(null);
+    }
+
+    /**
      * Returns a string representation for this type. It is similar, yet not identical
      * to a Java source code representation.
      *

--- a/core/src/main/java/org/jboss/jandex/TypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariable.java
@@ -147,6 +147,15 @@ public final class TypeVariable extends Type {
         return new TypeVariable(identifier, bounds, newAnnotations, hasImplicitObjectBound());
     }
 
+    @Override
+    Type withoutAnnotations() {
+        Type[] newBounds = new Type[bounds.length];
+        for (int i = 0; i < bounds.length; i++) {
+            newBounds[i] = bounds[i].withoutAnnotations();
+        }
+        return new TypeVariable(identifier, newBounds, null, hasImplicitObjectBound());
+    }
+
     TypeVariable copyType(int boundIndex, Type bound) {
         if (boundIndex > bounds.length) {
             throw new IllegalArgumentException("Bound index outside of bounds");

--- a/core/src/main/java/org/jboss/jandex/WildcardType.java
+++ b/core/src/main/java/org/jboss/jandex/WildcardType.java
@@ -179,6 +179,11 @@ public class WildcardType extends Type {
         return new WildcardType(bound, isExtends, newAnnotations);
     }
 
+    @Override
+    Type withoutAnnotations() {
+        return new WildcardType(bound.withoutAnnotations(), isExtends, null);
+    }
+
     Type copyType(Type bound) {
         return new WildcardType(bound, isExtends, annotationArray());
     }

--- a/core/src/test/java/org/jboss/jandex/test/RecordTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/RecordTestCase.java
@@ -156,27 +156,43 @@ public class RecordTestCase {
 
     @Test
     public void canonicalCtor() {
-        ClassInfo rec = index.getClassByName("test.RecordWithNoComponentsAndDefaultCanonicalCtor");
+        ClassInfo rec = index.getClassByName("test.Record0WithDefaultCanonicalCtor");
         assertEquals(1, rec.constructors().size());
         assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
 
-        rec = index.getClassByName("test.RecordWithNoComponentsAndCompactCanonicalCtor");
+        rec = index.getClassByName("test.Record0WithCompactCanonicalCtor");
         assertEquals(1, rec.constructors().size());
         assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
 
-        rec = index.getClassByName("test.RecordWithNoComponentsAndCustomCanonicalCtor");
+        rec = index.getClassByName("test.Record0WithCustomCanonicalCtor");
         assertEquals(1, rec.constructors().size());
         assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
 
-        rec = index.getClassByName("test.RecordWithDefaultCanonicalCtor");
+        rec = index.getClassByName("test.Record1WithDefaultCanonicalCtor");
         assertEquals(1, rec.constructors().size());
         assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
 
-        rec = index.getClassByName("test.RecordWithCompactCanonicalCtor");
+        rec = index.getClassByName("test.Record1WithCompactCanonicalCtor");
         assertEquals(1, rec.constructors().size());
         assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
 
-        rec = index.getClassByName("test.RecordWithCustomCanonicalCtor");
+        rec = index.getClassByName("test.Record1WithCustomCanonicalCtor");
+        assertEquals(1, rec.constructors().size());
+        assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
+
+        rec = index.getClassByName("test.Record2WithDefaultCanonicalCtor");
+        assertEquals(1, rec.constructors().size());
+        assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
+
+        rec = index.getClassByName("test.Record2WithCompactCanonicalCtor");
+        assertEquals(1, rec.constructors().size());
+        assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
+
+        rec = index.getClassByName("test.Record2WithCustomCanonicalCtor");
+        assertEquals(1, rec.constructors().size());
+        assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
+
+        rec = index.getClassByName("test.RecordWithBuggyAnnotation");
         assertEquals(1, rec.constructors().size());
         assertEquals(rec.constructors().get(0), rec.canonicalRecordConstructor());
 
@@ -209,21 +225,22 @@ public class RecordTestCase {
         indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$ComponentAnnotation.class"));
         indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$FieldAnnotation.class"));
         indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$AccessorAnnotation.class"));
-        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordWithCompactCanonicalCtor.class"));
-        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordWithCustomCanonicalCtor.class"));
-        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordWithDefaultCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record0WithCompactCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record0WithCustomCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record0WithDefaultCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record1WithCompactCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record1WithCustomCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record1WithDefaultCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record2WithCompactCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record2WithCustomCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/Record2WithDefaultCanonicalCtor.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordWithBuggyAnnotation.class"));
         indexer.index(
                 getClass().getClassLoader().getResourceAsStream("test/RecordWithMultipleCtorsAndCompactCanonicalCtor.class"));
         indexer.index(
                 getClass().getClassLoader().getResourceAsStream("test/RecordWithMultipleCtorsAndCustomCanonicalCtor.class"));
         indexer.index(
                 getClass().getClassLoader().getResourceAsStream("test/RecordWithMultipleCtorsAndDefaultCanonicalCtor.class"));
-        indexer.index(
-                getClass().getClassLoader().getResourceAsStream("test/RecordWithNoComponentsAndCompactCanonicalCtor.class"));
-        indexer.index(
-                getClass().getClassLoader().getResourceAsStream("test/RecordWithNoComponentsAndCustomCanonicalCtor.class"));
-        indexer.index(
-                getClass().getClassLoader().getResourceAsStream("test/RecordWithNoComponentsAndDefaultCanonicalCtor.class"));
 
         indexer.indexClass(RecordTestCase.class);
 

--- a/core/src/test/java/org/jboss/jandex/test/TypeNameTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeNameTest.java
@@ -25,6 +25,8 @@ public class TypeNameTest {
 
         String[][] array();
 
+        List<? extends Number>[] genericArray();
+
         // annotations are present to make sure the `ArrayType` has multiple levels of nesting
         @MyAnnotation("1")
         String[] @MyAnnotation("2") [][] @MyAnnotation("3") [] annotatedArray();
@@ -70,6 +72,7 @@ public class TypeNameTest {
         assertEquals("java.lang.String", typeName(clazz, "clazz"));
         assertEquals("java.util.List", typeName(clazz, "parameterized"));
         assertEquals("[[Ljava.lang.String;", typeName(clazz, "array"));
+        assertEquals("[Ljava.util.List;", typeName(clazz, "genericArray"));
         assertEquals("[[[[Ljava.lang.String;", typeName(clazz, "annotatedArray"));
         assertEquals("java.lang.Object", typeName(clazz, "typeParameter"));
         assertEquals("java.lang.Number", typeName(clazz, "typeParameterWithSingleBound"));

--- a/core/src/test/java/org/jboss/jandex/test/TypeWithoutAnnotationsTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeWithoutAnnotationsTest.java
@@ -1,0 +1,141 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.junit.jupiter.api.Test;
+
+public class TypeWithoutAnnotationsTest {
+    interface TestMethods<X> {
+        @MyAnnotation("1")
+        int primitive();
+
+        @MyAnnotation("2")
+        String clazz();
+
+        @MyAnnotation("3")
+        List<String> parameterized();
+
+        @MyAnnotation("4")
+        String[][] array();
+
+        @MyAnnotation("5")
+        List<@MyAnnotation("6") ? extends @MyAnnotation("7") Number> @MyAnnotation("8") [] genericArray();
+
+        // annotations are present to make sure the `ArrayType` has multiple levels of nesting
+        @MyAnnotation("9")
+        String[] @MyAnnotation("10") [][] @MyAnnotation("11") [] annotatedArray();
+
+        @MyAnnotation("12")
+        X typeParameter();
+
+        @MyAnnotation("13")
+        <Y extends @MyAnnotation("14") Number> Y typeParameterWithSingleBound();
+
+        @MyAnnotation("15")
+        <Y extends @MyAnnotation("16") Number & @MyAnnotation("17") Comparable<@MyAnnotation("18") Y>> Y typeParameterWithMultipleBounds();
+
+        @MyAnnotation("19")
+        <Y extends @MyAnnotation("20") Comparable<@MyAnnotation("21") Y>> Y typeParameterWithSingleParameterizedBound();
+
+        @MyAnnotation("22")
+        <Y extends @MyAnnotation("23") Comparable<@MyAnnotation("24") Y> & @MyAnnotation("25") Serializable> Y typeParameterWithMultipleBoundsFirstParameterized();
+
+        @MyAnnotation("26")
+        <Y extends @MyAnnotation("27") Serializable & @MyAnnotation("28") Comparable<@MyAnnotation("29") Y>> Y typeParameterWithMultipleBoundsSecondParameterized();
+
+        @MyAnnotation("30")
+        List<@MyAnnotation("31") ?> unboundedWildcard();
+
+        @MyAnnotation("32")
+        List<@MyAnnotation("33") ? extends @MyAnnotation("34") Number> wildcardWithUpperBound();
+
+        @MyAnnotation("35")
+        List<@MyAnnotation("36") ? super @MyAnnotation("37") String> wildcardWithLowerBound();
+
+        @MyAnnotation("38")
+        List<@MyAnnotation("39") ? extends @MyAnnotation("40") X> wildcardWithUnboundedTypeParameterAsUpperBound();
+
+        @MyAnnotation("41")
+        <@MyAnnotation("42") Y extends @MyAnnotation("43") Number> List<@MyAnnotation("44") ? extends @MyAnnotation("45") Y> wildcardWithBoundedTypeParameterAsUpperBound();
+
+        @MyAnnotation("46")
+        <@MyAnnotation("47") Y extends @MyAnnotation("48") Number> List<@MyAnnotation("49") ? super @MyAnnotation("50") Y> wildcardWithBoundedTypeParameterAsLowerBound();
+    }
+
+    static class NestedClass<@MyAnnotation("51") T> {
+        class InnerClass<@MyAnnotation("52") U extends @MyAnnotation("53") T> {
+        }
+    }
+
+    @Test
+    public void test() throws IOException, ReflectiveOperationException {
+        // intentionally _not_ indexing `NestedClass`, so that the type parameter bound of `InnerClass` is unresolved
+        Index index = Index.of(TestMethods.class, NestedClass.InnerClass.class);
+
+        ClassInfo clazz = index.getClassByName(TestMethods.class);
+        assertEquals("int",
+                withoutAnnotations(clazz, "primitive"));
+        assertEquals("java.lang.String",
+                withoutAnnotations(clazz, "clazz"));
+        assertEquals("java.util.List<java.lang.String>",
+                withoutAnnotations(clazz, "parameterized"));
+        assertEquals("java.lang.String[][]",
+                withoutAnnotations(clazz, "array"));
+        assertEquals("java.util.List<? extends java.lang.Number>[]",
+                withoutAnnotations(clazz, "genericArray"));
+        assertEquals("java.lang.String[][][][]",
+                withoutAnnotations(clazz, "annotatedArray"));
+        assertEquals("X",
+                withoutAnnotations(clazz, "typeParameter"));
+        assertEquals("Y extends java.lang.Number",
+                withoutAnnotations(clazz, "typeParameterWithSingleBound"));
+        assertEquals("Y extends java.lang.Number & java.lang.Comparable<Y>",
+                withoutAnnotations(clazz, "typeParameterWithMultipleBounds"));
+        assertEquals("Y extends java.lang.Comparable<Y>",
+                withoutAnnotations(clazz, "typeParameterWithSingleParameterizedBound"));
+        assertEquals("Y extends java.lang.Comparable<Y> & java.io.Serializable",
+                withoutAnnotations(clazz, "typeParameterWithMultipleBoundsFirstParameterized"));
+        assertEquals("Y extends java.io.Serializable & java.lang.Comparable<Y>",
+                withoutAnnotations(clazz, "typeParameterWithMultipleBoundsSecondParameterized"));
+        assertEquals("? extends java.lang.Object",
+                firstTypeArgumentWithoutAnnotations(clazz, "unboundedWildcard"));
+        assertEquals("? extends java.lang.Number",
+                firstTypeArgumentWithoutAnnotations(clazz, "wildcardWithUpperBound"));
+        assertEquals("? super java.lang.String",
+                firstTypeArgumentWithoutAnnotations(clazz, "wildcardWithLowerBound"));
+        assertEquals("? extends X",
+                firstTypeArgumentWithoutAnnotations(clazz, "wildcardWithUnboundedTypeParameterAsUpperBound"));
+        assertEquals("? extends Y",
+                firstTypeArgumentWithoutAnnotations(clazz, "wildcardWithBoundedTypeParameterAsUpperBound"));
+        assertEquals("? super Y",
+                firstTypeArgumentWithoutAnnotations(clazz, "wildcardWithBoundedTypeParameterAsLowerBound"));
+
+        TypeVariable u = index.getClassByName(NestedClass.InnerClass.class).typeParameters().get(0);
+        assertEquals("U extends T", withoutAnnotations(u));
+    }
+
+    private String withoutAnnotations(ClassInfo clazz, String method) throws ReflectiveOperationException {
+        Type jandexType = clazz.firstMethod(method).returnType();
+        return withoutAnnotations(jandexType);
+    }
+
+    private String firstTypeArgumentWithoutAnnotations(ClassInfo clazz, String method) throws ReflectiveOperationException {
+        Type jandexType = clazz.firstMethod(method).returnType().asParameterizedType().arguments().get(0);
+        return withoutAnnotations(jandexType);
+    }
+
+    private String withoutAnnotations(Type type) throws ReflectiveOperationException {
+        Method withoutAnnotations = Type.class.getDeclaredMethod("withoutAnnotations");
+        withoutAnnotations.setAccessible(true);
+        return withoutAnnotations.invoke(type).toString();
+    }
+}

--- a/test-data/src/main/java/test/Record0WithCompactCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record0WithCompactCanonicalCtor.java
@@ -1,0 +1,6 @@
+package test;
+
+public record Record0WithCompactCanonicalCtor() {
+    public Record0WithCompactCanonicalCtor {
+    }
+}

--- a/test-data/src/main/java/test/Record0WithCustomCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record0WithCustomCanonicalCtor.java
@@ -1,0 +1,6 @@
+package test;
+
+public record Record0WithCustomCanonicalCtor() {
+    public Record0WithCustomCanonicalCtor() {
+    }
+}

--- a/test-data/src/main/java/test/Record0WithDefaultCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record0WithDefaultCanonicalCtor.java
@@ -1,0 +1,4 @@
+package test;
+
+public record Record0WithDefaultCanonicalCtor() {
+}

--- a/test-data/src/main/java/test/Record1WithCompactCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record1WithCompactCanonicalCtor.java
@@ -1,0 +1,9 @@
+package test;
+
+public record Record1WithCompactCanonicalCtor(String foo) {
+    public Record1WithCompactCanonicalCtor {
+        if (foo == null) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/test-data/src/main/java/test/Record1WithCustomCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record1WithCustomCanonicalCtor.java
@@ -1,0 +1,11 @@
+package test;
+
+public record Record1WithCustomCanonicalCtor(String foo) {
+    public Record1WithCustomCanonicalCtor(String foo) {
+        if (foo == null) {
+            throw new IllegalArgumentException();
+        }
+
+        this.foo = foo;
+    }
+}

--- a/test-data/src/main/java/test/Record1WithDefaultCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record1WithDefaultCanonicalCtor.java
@@ -1,0 +1,4 @@
+package test;
+
+public record Record1WithDefaultCanonicalCtor(String foo) {
+}

--- a/test-data/src/main/java/test/Record2WithCompactCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record2WithCompactCanonicalCtor.java
@@ -1,15 +1,12 @@
 package test;
 
-public record RecordWithCustomCanonicalCtor(int foo, String bar) {
-    public RecordWithCustomCanonicalCtor(int foo, String bar) {
+public record Record2WithCompactCanonicalCtor(int foo, String bar) {
+    public Record2WithCompactCanonicalCtor {
         if (foo < 0) {
             throw new IllegalArgumentException();
         }
         if (bar == null) {
             throw new IllegalArgumentException();
         }
-
-        this.foo = foo;
-        this.bar = bar;
     }
 }

--- a/test-data/src/main/java/test/Record2WithCustomCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record2WithCustomCanonicalCtor.java
@@ -1,12 +1,15 @@
 package test;
 
-public record RecordWithCompactCanonicalCtor(int foo, String bar) {
-    public RecordWithCompactCanonicalCtor {
+public record Record2WithCustomCanonicalCtor(int foo, String bar) {
+    public Record2WithCustomCanonicalCtor(int foo, String bar) {
         if (foo < 0) {
             throw new IllegalArgumentException();
         }
         if (bar == null) {
             throw new IllegalArgumentException();
         }
+
+        this.foo = foo;
+        this.bar = bar;
     }
 }

--- a/test-data/src/main/java/test/Record2WithDefaultCanonicalCtor.java
+++ b/test-data/src/main/java/test/Record2WithDefaultCanonicalCtor.java
@@ -1,0 +1,4 @@
+package test;
+
+public record Record2WithDefaultCanonicalCtor(int foo, String bar) {
+}

--- a/test-data/src/main/java/test/RecordWithBuggyAnnotation.java
+++ b/test-data/src/main/java/test/RecordWithBuggyAnnotation.java
@@ -1,0 +1,10 @@
+package test;
+
+import java.util.List;
+
+public record RecordWithBuggyAnnotation(List<@Nullable String> list) {
+    // if this compact constructor is present, the type annotation on the constructor has a wrong type target
+    // the bug is gone when this compact constructor is removed
+    public RecordWithBuggyAnnotation {
+    }
+}

--- a/test-data/src/main/java/test/RecordWithDefaultCanonicalCtor.java
+++ b/test-data/src/main/java/test/RecordWithDefaultCanonicalCtor.java
@@ -1,4 +1,0 @@
-package test;
-
-public record RecordWithDefaultCanonicalCtor(int foo, String bar) {
-}

--- a/test-data/src/main/java/test/RecordWithNoComponentsAndCompactCanonicalCtor.java
+++ b/test-data/src/main/java/test/RecordWithNoComponentsAndCompactCanonicalCtor.java
@@ -1,6 +1,0 @@
-package test;
-
-public record RecordWithNoComponentsAndCompactCanonicalCtor() {
-    public RecordWithNoComponentsAndCompactCanonicalCtor {
-    }
-}

--- a/test-data/src/main/java/test/RecordWithNoComponentsAndCustomCanonicalCtor.java
+++ b/test-data/src/main/java/test/RecordWithNoComponentsAndCustomCanonicalCtor.java
@@ -1,6 +1,0 @@
-package test;
-
-public record RecordWithNoComponentsAndCustomCanonicalCtor() {
-    public RecordWithNoComponentsAndCustomCanonicalCtor() {
-    }
-}

--- a/test-data/src/main/java/test/RecordWithNoComponentsAndDefaultCanonicalCtor.java
+++ b/test-data/src/main/java/test/RecordWithNoComponentsAndDefaultCanonicalCtor.java
@@ -1,4 +1,0 @@
-package test;
-
-public record RecordWithNoComponentsAndDefaultCanonicalCtor() {
-}


### PR DESCRIPTION
This method had 2 flaws:

- in case of 1 record component, it never worked, because we don't store record component positions in case there's just one;
- it compared types including annotations, which should generally work, but javac sometimes emits type annotations incorrectly.

This commit fixes those issues:

- in case of 1 record component, it no longer looks at component positions, because it's not necessary;
- it compares types after removing all type annotations, which guards against those javac bugs.