### PR TITLE
Add AnnotationOverlay option to cache all annotation instances

### DIFF
--- a/core/src/main/java/org/jboss/jandex/AnnotationOverlay.java
+++ b/core/src/main/java/org/jboss/jandex/AnnotationOverlay.java
@@ -207,6 +207,7 @@ public interface AnnotationOverlay {
         private boolean compatibleMode;
         private boolean runtimeAnnotationsOnly;
         private boolean inheritedAnnotations;
+        private boolean cacheAll;
 
         Builder(IndexView index, Collection<AnnotationTransformation> annotationTransformations) {
             this.index = index;
@@ -255,12 +256,24 @@ public interface AnnotationOverlay {
         }
 
         /**
+         * When called, the built annotation overlay shall cache a copy of all annotations, at a higher memory cost,
+         * instead of only caching annotations of a declaration where an annotation transformer was applied to.
+         *
+         *
+         * @return this builder
+         */
+        public Builder cacheAll() {
+            cacheAll = true;
+            return this;
+        }
+
+        /**
          * Builds and returns an annotation overlay based on the configuration of this builder.
          *
          * @return the annotation overlay, never {@code null}
          */
         public AnnotationOverlay build() {
-            return new AnnotationOverlayImpl(index, compatibleMode, runtimeAnnotationsOnly, inheritedAnnotations,
+            return new AnnotationOverlayImpl(index, compatibleMode, runtimeAnnotationsOnly, inheritedAnnotations, cacheAll,
                     annotationTransformations);
         }
     }

--- a/core/src/main/java/org/jboss/jandex/MutableAnnotationOverlayImpl.java
+++ b/core/src/main/java/org/jboss/jandex/MutableAnnotationOverlayImpl.java
@@ -10,7 +10,7 @@ final class MutableAnnotationOverlayImpl extends AnnotationOverlayImpl implement
 
     MutableAnnotationOverlayImpl(IndexView index, boolean compatibleMode, boolean runtimeAnnotationsOnly,
             boolean inheritedAnnotations) {
-        super(index, compatibleMode, runtimeAnnotationsOnly, inheritedAnnotations, Collections.emptyList());
+        super(index, compatibleMode, runtimeAnnotationsOnly, inheritedAnnotations, false, Collections.emptyList());
     }
 
     @Override

--- a/core/src/test/java/org/jboss/jandex/test/AnnotationOverlayTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/AnnotationOverlayTest.java
@@ -233,97 +233,106 @@ public class AnnotationOverlayTest {
 
         for (boolean inheritedAnnotations : Arrays.asList(true, false)) {
             for (boolean runtimeAnnotationsOnly : Arrays.asList(true, false)) {
-                AnnotationOverlay.Builder builder = AnnotationOverlay.builder(index, Arrays.asList(transformations));
-                if (inheritedAnnotations) {
-                    builder.inheritedAnnotations();
-                }
-                if (runtimeAnnotationsOnly) {
-                    builder.runtimeAnnotationsOnly();
-                }
-                AnnotationOverlay overlay = builder.build();
-
-                StringBuilder values = new StringBuilder();
-
-                ClassInfo clazz = index.getClassByName(AnnotatedClass.class);
-                assertNotNull(clazz);
-
-                assertFalse(overlay.hasAnnotation(clazz, MyNotInheritedAnnotation.class));
-                assertNull(overlay.annotation(clazz, MyNotInheritedAnnotation.class));
-                assertEquals(0, overlay.annotationsWithRepeatable(clazz, MyNotInheritedAnnotation.class).size());
-
-                if (inheritedAnnotations) {
-                    assertTrue(overlay.hasAnnotation(clazz, MyInheritedAnnotation.class));
-                    assertNotNull(overlay.annotation(clazz, MyInheritedAnnotation.class));
-                    assertNotNull(overlay.annotation(clazz, MyInheritedAnnotation.class).target());
-                    assertEquals("i", overlay.annotation(clazz, MyInheritedAnnotation.class).value().asString());
-                    assertEquals(1, overlay.annotationsWithRepeatable(clazz, MyInheritedAnnotation.class).size());
-                } else {
-                    assertFalse(overlay.hasAnnotation(clazz, MyInheritedAnnotation.class));
-                    assertNull(overlay.annotation(clazz, MyInheritedAnnotation.class));
-                    assertEquals(0, overlay.annotationsWithRepeatable(clazz, MyInheritedAnnotation.class).size());
-                }
-
-                FieldInfo field = clazz.field("field");
-                assertNotNull(field);
-
-                MethodInfo method = clazz.firstMethod("method");
-                assertNotNull(method);
-
-                MethodParameterInfo parameter1 = method.parameters().get(0);
-                assertNotNull(parameter1);
-
-                MethodParameterInfo parameter2 = method.parameters().get(1);
-                assertNotNull(parameter2);
-
-                for (Declaration declaration : Arrays.asList(clazz, field, method, parameter1, parameter2)) {
-                    if (overlay.hasAnnotation(declaration, MyAnnotation.DOT_NAME)) {
-                        assertNotNull(overlay.annotation(declaration, MyAnnotation.DOT_NAME).target());
-                        values.append(overlay.annotation(declaration, MyAnnotation.DOT_NAME).value().asString()).append("_");
+                for (boolean cacheAll : Arrays.asList(true, false)) {
+                    AnnotationOverlay.Builder builder = AnnotationOverlay.builder(index, Arrays.asList(transformations));
+                    if (inheritedAnnotations) {
+                        builder.inheritedAnnotations();
                     }
-                    if (overlay.hasAnnotation(declaration, MyOtherAnnotation.DOT_NAME)) {
-                        assertNotNull(overlay.annotation(declaration, MyOtherAnnotation.DOT_NAME).target());
-                        values.append(overlay.annotation(declaration, MyOtherAnnotation.DOT_NAME).value().asString())
-                                .append("_");
+                    if (runtimeAnnotationsOnly) {
+                        builder.runtimeAnnotationsOnly();
                     }
-                    if (declaration != method) {
-                        if (overlay.hasAnnotation(declaration, MyRepeatableAnnotation.DOT_NAME)) {
-                            assertNotNull(overlay.annotation(declaration, MyRepeatableAnnotation.DOT_NAME).target());
-                            values.append(overlay.annotation(declaration, MyRepeatableAnnotation.DOT_NAME).value().asString())
+                    if (cacheAll) {
+                        builder.cacheAll();
+                    }
+                    AnnotationOverlay overlay = builder.build();
+
+                    StringBuilder values = new StringBuilder();
+
+                    ClassInfo clazz = index.getClassByName(AnnotatedClass.class);
+                    assertNotNull(clazz);
+
+                    assertFalse(overlay.hasAnnotation(clazz, MyNotInheritedAnnotation.class));
+                    assertNull(overlay.annotation(clazz, MyNotInheritedAnnotation.class));
+                    assertEquals(0, overlay.annotationsWithRepeatable(clazz, MyNotInheritedAnnotation.class).size());
+
+                    if (inheritedAnnotations) {
+                        assertTrue(overlay.hasAnnotation(clazz, MyInheritedAnnotation.class));
+                        assertNotNull(overlay.annotation(clazz, MyInheritedAnnotation.class));
+                        assertNotNull(overlay.annotation(clazz, MyInheritedAnnotation.class).target());
+                        assertEquals("i", overlay.annotation(clazz, MyInheritedAnnotation.class).value().asString());
+                        assertEquals(1, overlay.annotationsWithRepeatable(clazz, MyInheritedAnnotation.class).size());
+                    } else {
+                        assertFalse(overlay.hasAnnotation(clazz, MyInheritedAnnotation.class));
+                        assertNull(overlay.annotation(clazz, MyInheritedAnnotation.class));
+                        assertEquals(0, overlay.annotationsWithRepeatable(clazz, MyInheritedAnnotation.class).size());
+                    }
+
+                    FieldInfo field = clazz.field("field");
+                    assertNotNull(field);
+
+                    MethodInfo method = clazz.firstMethod("method");
+                    assertNotNull(method);
+
+                    MethodParameterInfo parameter1 = method.parameters().get(0);
+                    assertNotNull(parameter1);
+
+                    MethodParameterInfo parameter2 = method.parameters().get(1);
+                    assertNotNull(parameter2);
+
+                    for (Declaration declaration : Arrays.asList(clazz, field, method, parameter1, parameter2)) {
+                        if (overlay.hasAnnotation(declaration, MyAnnotation.DOT_NAME)) {
+                            assertNotNull(overlay.annotation(declaration, MyAnnotation.DOT_NAME).target());
+                            values.append(overlay.annotation(declaration, MyAnnotation.DOT_NAME).value().asString())
                                     .append("_");
                         }
-                        if (overlay.hasAnnotation(declaration, MyRepeatableAnnotation.List.DOT_NAME)) {
-                            AnnotationInstance annotation = overlay.annotation(declaration,
-                                    MyRepeatableAnnotation.List.DOT_NAME);
-                            assertNotNull(annotation.target());
-                            for (AnnotationInstance nestedAnnotation : annotation.value().asNestedArray()) {
-                                values.append(nestedAnnotation.value().asString()).append("_");
+                        if (overlay.hasAnnotation(declaration, MyOtherAnnotation.DOT_NAME)) {
+                            assertNotNull(overlay.annotation(declaration, MyOtherAnnotation.DOT_NAME).target());
+                            values.append(overlay.annotation(declaration, MyOtherAnnotation.DOT_NAME).value().asString())
+                                    .append("_");
+                        }
+                        if (declaration != method) {
+                            if (overlay.hasAnnotation(declaration, MyRepeatableAnnotation.DOT_NAME)) {
+                                assertNotNull(overlay.annotation(declaration, MyRepeatableAnnotation.DOT_NAME).target());
+                                values.append(
+                                        overlay.annotation(declaration, MyRepeatableAnnotation.DOT_NAME).value().asString())
+                                        .append("_");
+                            }
+                            if (overlay.hasAnnotation(declaration, MyRepeatableAnnotation.List.DOT_NAME)) {
+                                AnnotationInstance annotation = overlay.annotation(declaration,
+                                        MyRepeatableAnnotation.List.DOT_NAME);
+                                assertNotNull(annotation.target());
+                                for (AnnotationInstance nestedAnnotation : annotation.value().asNestedArray()) {
+                                    values.append(nestedAnnotation.value().asString()).append("_");
+                                }
+                            }
+                        } else { // just to test `annotationsWithRepeatable`, no other reason
+                            for (AnnotationInstance annotation : overlay.annotationsWithRepeatable(declaration,
+                                    MyRepeatableAnnotation.DOT_NAME)) {
+                                assertNotNull(annotation.target());
+                                values.append(annotation.value().asString()).append("_");
                             }
                         }
-                    } else { // just to test `annotationsWithRepeatable`, no other reason
-                        for (AnnotationInstance annotation : overlay.annotationsWithRepeatable(declaration,
-                                MyRepeatableAnnotation.DOT_NAME)) {
-                            assertNotNull(annotation.target());
-                            values.append(annotation.value().asString()).append("_");
+
+                        if (runtimeAnnotationsOnly) {
+                            assertFalse(overlay.hasAnnotation(declaration, MyClassRetainedAnnotation.class));
+                            assertNull(overlay.annotation(declaration, MyClassRetainedAnnotation.class));
+                            assertEquals(0,
+                                    overlay.annotationsWithRepeatable(declaration, MyClassRetainedAnnotation.class).size());
+                        } else {
+                            assertTrue(overlay.hasAnnotation(declaration, MyClassRetainedAnnotation.class));
+                            assertNotNull(overlay.annotation(declaration, MyClassRetainedAnnotation.class));
+                            assertNotNull(overlay.annotation(declaration, MyClassRetainedAnnotation.class).target());
+                            assertEquals(1,
+                                    overlay.annotationsWithRepeatable(declaration, MyClassRetainedAnnotation.class).size());
                         }
                     }
 
-                    if (runtimeAnnotationsOnly) {
-                        assertFalse(overlay.hasAnnotation(declaration, MyClassRetainedAnnotation.class));
-                        assertNull(overlay.annotation(declaration, MyClassRetainedAnnotation.class));
-                        assertEquals(0, overlay.annotationsWithRepeatable(declaration, MyClassRetainedAnnotation.class).size());
-                    } else {
-                        assertTrue(overlay.hasAnnotation(declaration, MyClassRetainedAnnotation.class));
-                        assertNotNull(overlay.annotation(declaration, MyClassRetainedAnnotation.class));
-                        assertNotNull(overlay.annotation(declaration, MyClassRetainedAnnotation.class).target());
-                        assertEquals(1, overlay.annotationsWithRepeatable(declaration, MyClassRetainedAnnotation.class).size());
+                    if (values.length() > 0) {
+                        values.deleteCharAt(values.length() - 1);
                     }
-                }
 
-                if (values.length() > 0) {
-                    values.deleteCharAt(values.length() - 1);
+                    assertEquals(expectedValues, values.toString());
                 }
-
-                assertEquals(expectedValues, values.toString());
             }
         }
     }


### PR DESCRIPTION
Instead of only the transformed ones of a declaration site

When activated, this saves about 20ms of hot reload startup time.


During investigation for https://github.com/quarkusio/quarkus/issues/45631, I noticed that `getOriginalAnnotations` was called a lot of times (99k times).
After the sentinel value, and hard coding this `getAnnotationsFor` to always cache everything, this reduced to 4,8k times, and showed about 20ms of improvement.
My guess is, that this reduction happens mostly because, `getOriginalAnnotations` construct a hashset for the annotations of a declaration. Additionally, e.g. ClassInfo#declaredAnnotations also constructs an additional arraylist of the ClassInfos annotation.


The original mission statement (https://github.com/smallrye/jandex/issues/255) of the AnnotationOverlay stated for Sentinel:
>  In case no annotation transformation affected given declaration, we should be able to store a sentinel value that means "just look it up from the passed annotation target". That would conserve memory.

I decided to still preserve this implementation detail. Could be usefull for e.g. Environments, where jandex is still accessible at runtime (maybe wildfly? no idea).

Therefore I implemented this change as an addtional option for the builder, called for now `cacheAll`. Please suggest other names!
When not activated, the annotation overlay caches only the annotations of declarations, where an annotation transformer had any impact.
When activated, the annotation overlay additonally also cached any non transformer affected declarations annotations.





I took the about 20ms improvement measurement, by starting quarkus in dev mode (mvn clean compile quarkus:dev), and then pressing `s` 6 times, which forces hot reloads.
Number is taken from the "(Aesh InputStream Reader) Live reload total time:" line since that is the time that matters to users.

For Quarkus 3.18.2:
```
673ms
618ms
610ms
583ms
590ms
655ms
avg 621,5ms
```

For Quarkus 3.18.2 with this patch:
```
639ms
613ms
657ms
578ms
543ms
539ms
avg 594,8333333ms
```



My plan would be to activate this option for now only in quarkus dev mode.