### PR TITLE
add ClassInfo.enclosingClassAlways()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -50,7 +50,7 @@ import java.util.Set;
  */
 final class IndexReaderV2 extends IndexReaderImpl {
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 12;
+    static final int MAX_VERSION = 13;
     private static final byte NULL_TARGET_TAG = 0;
     private static final byte FIELD_TAG = 1;
     private static final byte METHOD_TAG = 2;
@@ -613,12 +613,16 @@ final class IndexReaderV2 extends IndexReaderImpl {
         }
 
         DotName enclosingClass = null;
-        ClassInfo.EnclosingMethodInfo enclosingMethod = null;
         String simpleName = null;
+        DotName enclosingClassInInitializer = null;
+        ClassInfo.EnclosingMethodInfo enclosingMethod = null;
 
         if (hasNesting) {
             enclosingClass = nameTable[stream.readPackedU32()];
             simpleName = stringTable[stream.readPackedU32()];
+            if (version >= 13) {
+                enclosingClassInInitializer = nameTable[stream.readPackedU32()];
+            }
             enclosingMethod = hasEnclosingMethod ? readEnclosingMethod(stream) : null;
         }
 
@@ -658,6 +662,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
             // Version 8 and earlier records inner type info regardless of
             // whether or not it is an inner type
             clazz.setInnerClassInfo(enclosingClass, simpleName, version >= 9);
+            clazz.setEnclosingClassInInitializer(enclosingClassInInitializer);
         }
         if (memberClasses != null) {
             clazz.setMemberClasses(memberClasses);

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -869,11 +869,15 @@ public final class Indexer {
     private void processEnclosingMethod(DataInputStream data, ClassInfo target) throws IOException {
         int classIndex = data.readUnsignedShort();
         int index = data.readUnsignedShort();
-        if (index == 0) {
-            return; // Enclosed in a static or an instance variable
-        }
 
         DotName enclosingClass = decodeClassEntry(classIndex);
+
+        if (index == 0) {
+            // enclosed in a static/instance/field initializer
+            target.setEnclosingClassInInitializer(enclosingClass);
+            return;
+        }
+
         NameAndType nameAndType = decodeNameAndTypeEntry(index);
 
         IntegerHolder pos = new IntegerHolder();

--- a/core/src/test/java/org/jboss/jandex/test/NestedClassesTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/NestedClassesTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -60,13 +61,30 @@ public class NestedClassesTest {
             class M {
             }
         }
+
+        static Class<?> localClassInStaticInitializer;
+        static Class<?> anonymousClassInStaticInitializer;
+
+        static {
+            class N {
+            }
+            localClassInStaticInitializer = N.class;
+
+            anonymousClassInStaticInitializer = new Object() {
+            }.getClass();
+        }
+
+        static Class<?> anonymousClassInFieldInitializer = new Object() {
+        }.getClass();
     }
 
     @Test
     public void test() throws IOException {
         Index index = Index.of(A.class, A.B.class, A.B.C.class, A.D.class,
                 A.localClass()[0], A.localClass()[1], A.anonymousClass()[0], A.anonymousClass()[1],
-                A.H.class, A.H.I.class, A.J.class, A.J.K.class, A.L.class, A.L.M.class);
+                A.H.class, A.H.I.class, A.J.class, A.J.K.class, A.L.class, A.L.M.class,
+                A.localClassInStaticInitializer, A.anonymousClassInStaticInitializer,
+                A.anonymousClassInFieldInitializer);
         test(index);
 
         test(IndexingUtil.roundtrip(index));
@@ -77,71 +95,103 @@ public class NestedClassesTest {
         checkMemberClasses(index, A.class, "B", "D", "H", "J", "L");
         checkEnclosingClass(index, A.class, "NestedClassesTest");
         checkEnclosingMethod(index, A.class, null, null);
+        checkEnclosingClassAlways(index, A.class, "NestedClassesTest");
 
         checkNestingType(index, A.B.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.B.class, "C");
         checkEnclosingClass(index, A.B.class, "A");
         checkEnclosingMethod(index, A.B.class, null, null);
+        checkEnclosingClassAlways(index, A.B.class, "A");
 
         checkNestingType(index, A.B.C.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.B.C.class); // empty
         checkEnclosingClass(index, A.B.C.class, "B");
         checkEnclosingMethod(index, A.B.C.class, null, null);
+        checkEnclosingClassAlways(index, A.B.C.class, "B");
 
         checkNestingType(index, A.D.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.D.class); // empty
         checkEnclosingClass(index, A.D.class, "A");
         checkEnclosingMethod(index, A.D.class, null, null);
+        checkEnclosingClassAlways(index, A.D.class, "A");
 
         checkNestingType(index, A.localClass()[0], ClassInfo.NestingType.LOCAL);
         checkMemberClasses(index, A.localClass()[0], "F");
         checkEnclosingClass(index, A.localClass()[0], null);
         checkEnclosingMethod(index, A.localClass()[0], "localClass", "A");
+        checkEnclosingClassAlways(index, A.localClass()[0], "A");
 
         checkNestingType(index, A.localClass()[1], ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.localClass()[1]); // empty
         checkEnclosingClass(index, A.localClass()[1], "not-null");
         checkEnclosingMethod(index, A.localClass()[1], null, null);
+        checkEnclosingClassAlways(index, A.localClass()[1], "not-null");
 
         checkNestingType(index, A.anonymousClass()[0], ClassInfo.NestingType.ANONYMOUS);
         checkMemberClasses(index, A.anonymousClass()[0], "G");
         checkEnclosingClass(index, A.anonymousClass()[0], null);
         checkEnclosingMethod(index, A.anonymousClass()[0], "anonymousClass", "A");
+        checkEnclosingClassAlways(index, A.anonymousClass()[0], "A");
 
         checkNestingType(index, A.anonymousClass()[1], ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.anonymousClass()[1]); // empty
         checkEnclosingClass(index, A.anonymousClass()[1], "not-null");
         checkEnclosingMethod(index, A.anonymousClass()[1], null, null);
+        checkEnclosingClassAlways(index, A.anonymousClass()[1], "not-null");
 
         checkNestingType(index, A.H.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.H.class, "I");
         checkEnclosingClass(index, A.H.class, "A");
         checkEnclosingMethod(index, A.H.class, null, null);
+        checkEnclosingClassAlways(index, A.H.class, "A");
 
         checkNestingType(index, A.H.I.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.H.I.class); // empty
         checkEnclosingClass(index, A.H.I.class, "H");
         checkEnclosingMethod(index, A.H.I.class, null, null);
+        checkEnclosingClassAlways(index, A.H.I.class, "H");
 
         checkNestingType(index, A.J.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.J.class, "K");
         checkEnclosingClass(index, A.J.class, "A");
         checkEnclosingMethod(index, A.J.class, null, null);
+        checkEnclosingClassAlways(index, A.J.class, "A");
 
         checkNestingType(index, A.J.K.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.J.K.class); // empty
         checkEnclosingClass(index, A.J.K.class, "J");
         checkEnclosingMethod(index, A.J.K.class, null, null);
+        checkEnclosingClassAlways(index, A.J.K.class, "J");
 
         checkNestingType(index, A.L.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.L.class, "M");
         checkEnclosingClass(index, A.L.class, "A");
         checkEnclosingMethod(index, A.L.class, null, null);
+        checkEnclosingClassAlways(index, A.L.class, "A");
 
         checkNestingType(index, A.L.M.class, ClassInfo.NestingType.INNER);
         checkMemberClasses(index, A.L.M.class); // empty
         checkEnclosingClass(index, A.L.M.class, "L");
         checkEnclosingMethod(index, A.L.M.class, null, null);
+        checkEnclosingClassAlways(index, A.L.M.class, "L");
+
+        checkNestingType(index, A.localClassInStaticInitializer, ClassInfo.NestingType.LOCAL);
+        checkMemberClasses(index, A.localClassInStaticInitializer); // empty
+        checkEnclosingClass(index, A.localClassInStaticInitializer, null);
+        checkEnclosingMethod(index, A.localClassInStaticInitializer, null, null);
+        checkEnclosingClassAlways(index, A.localClassInStaticInitializer, "A");
+
+        checkNestingType(index, A.anonymousClassInStaticInitializer, ClassInfo.NestingType.ANONYMOUS);
+        checkMemberClasses(index, A.anonymousClassInStaticInitializer); // empty
+        checkEnclosingClass(index, A.anonymousClassInStaticInitializer, null);
+        checkEnclosingMethod(index, A.anonymousClassInStaticInitializer, null, null);
+        checkEnclosingClassAlways(index, A.anonymousClassInStaticInitializer, "A");
+
+        checkNestingType(index, A.anonymousClassInFieldInitializer, ClassInfo.NestingType.ANONYMOUS);
+        checkMemberClasses(index, A.anonymousClassInFieldInitializer); // empty
+        checkEnclosingClass(index, A.anonymousClassInFieldInitializer, null);
+        checkEnclosingMethod(index, A.anonymousClassInFieldInitializer, null, null);
+        checkEnclosingClassAlways(index, A.anonymousClassInFieldInitializer, "A");
     }
 
     private void checkNestingType(Index index, Class<?> clazz, ClassInfo.NestingType expectedNestingType) {
@@ -159,8 +209,18 @@ public class NestedClassesTest {
     }
 
     private void checkEnclosingClass(Index index, Class<?> clazz, String expectedEnclosingClassName) {
+        doCheckEnclosingClass(index, clazz, ClassInfo::enclosingClass, expectedEnclosingClassName);
+    }
+
+    private void checkEnclosingClassAlways(Index index, Class<?> clazz, String expectedEnclosingClassName) {
+        doCheckEnclosingClass(index, clazz, ClassInfo::enclosingClassAlways, expectedEnclosingClassName);
+    }
+
+    private void doCheckEnclosingClass(Index index, Class<?> clazz, Function<ClassInfo, DotName> enclosingClassGetter,
+            String expectedEnclosingClassName) {
         ClassInfo classInfo = index.getClassByName(DotName.createSimple(clazz.getName()));
-        DotName enclosingClass = classInfo.enclosingClass();
+        DotName enclosingClass = enclosingClassGetter.apply(classInfo);
+
         if (expectedEnclosingClassName == null) {
             assertNull(enclosingClass);
         } else {

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -58,9 +58,11 @@ Updating to a newer minor or major version may require consumers of the Jandex i
 For reference, this table shows which Jandex version produces which persistent format version by default.
 It is also a maximum persistent index format version the given Jandex version can read.
 
-
 |===
 |Jandex version |Persistent format version
+
+|Jandex 3.3.x
+|13
 
 |Jandex 3.2.x
 |12


### PR DESCRIPTION
The `enclosingClassAlways()` returns an enclosing class not only for member classes, but also for local and anonymous classes, regardless of their declaration place. They may be declared in the body of a method or constructor, or in a static, instance or field initializer.

The behavior of `enclosingClass()` doesn't change.

Note that this commit increments the persistent format version.

Fixes #509