### PR TITLE
add IndexView.getKnownDirectImplementations() and getAllKnownImplementations()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/core/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -165,12 +165,12 @@ public class CompositeIndex implements IndexView {
     public Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName) {
         Set<ClassInfo> result = new HashSet<>();
 
-        Queue<DotName> workQueue = new ArrayDeque<>();
+        Queue<DotName> worklist = new ArrayDeque<>();
         Set<DotName> alreadyProcessed = new HashSet<>();
 
-        workQueue.add(interfaceName);
-        while (!workQueue.isEmpty()) {
-            DotName iface = workQueue.remove();
+        worklist.add(interfaceName);
+        while (!worklist.isEmpty()) {
+            DotName iface = worklist.remove();
             if (!alreadyProcessed.add(iface)) {
                 continue;
             }
@@ -178,12 +178,30 @@ public class CompositeIndex implements IndexView {
             for (IndexView index : indexes) {
                 for (ClassInfo directSubinterface : index.getKnownDirectSubinterfaces(iface)) {
                     result.add(directSubinterface);
-                    workQueue.add(directSubinterface.name());
+                    worklist.add(directSubinterface.name());
                 }
             }
         }
 
         return result;
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName) {
+        Set<ClassInfo> allKnown = new HashSet<>();
+        for (IndexView index : indexes) {
+            Collection<ClassInfo> list = index.getKnownDirectImplementations(interfaceName);
+            if (list != null) {
+                allKnown.addAll(list);
+            }
+        }
+        return Collections.unmodifiableSet(allKnown);
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownImplementations(DotName interfaceName) {
+        // no difference here
+        return getAllKnownImplementors(interfaceName);
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/EmptyIndex.java
+++ b/core/src/main/java/org/jboss/jandex/EmptyIndex.java
@@ -47,6 +47,16 @@ public final class EmptyIndex implements IndexView {
     }
 
     @Override
+    public Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownImplementations(DotName interfaceName) {
+        return Collections.emptySet();
+    }
+
+    @Override
     public Collection<ClassInfo> getKnownDirectImplementors(DotName interfaceName) {
         return Collections.emptySet();
     }

--- a/core/src/main/java/org/jboss/jandex/Index.java
+++ b/core/src/main/java/org/jboss/jandex/Index.java
@@ -70,7 +70,7 @@ public final class Index implements IndexView {
     final Map<DotName, AnnotationInstance[]> annotations;
     final Map<DotName, ClassInfo[]> subclasses;
     final Map<DotName, ClassInfo[]> subinterfaces;
-    final Map<DotName, ClassInfo[]> implementors;
+    final Map<DotName, ClassInfo[]> implementors; // note this also includes direct subinterfaces!
     final Map<DotName, ClassInfo> classes;
     final Map<DotName, ModuleInfo> modules;
     final Map<DotName, ClassInfo[]> users;
@@ -442,6 +442,37 @@ public final class Index implements IndexView {
         }
 
         return result;
+    }
+
+    @Override
+    public Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName) {
+        ClassInfo[] list = implementors.get(interfaceName);
+        if (list == null) {
+            return EMPTY_CLASSINFO_LIST;
+        }
+        List<ClassInfo> result = null;
+        for (int i = 0; i < list.length; i++) {
+            ClassInfo clazz = list[i];
+            if (clazz.isInterface()) {
+                if (result == null) {
+                    result = new ArrayList<>();
+                    for (int j = 0; j < i; j++) {
+                        result.add(list[j]);
+                    }
+                }
+            } else {
+                if (result != null) {
+                    result.add(clazz);
+                }
+            }
+        }
+        return result != null ? Collections.unmodifiableList(result) : new ImmutableArrayList<>(list);
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownImplementations(DotName interfaceName) {
+        // no difference here
+        return getAllKnownImplementors(interfaceName);
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/IndexView.java
+++ b/core/src/main/java/org/jboss/jandex/IndexView.java
@@ -41,163 +41,125 @@ public interface IndexView {
     /**
      * Gets all known classes by this index (those which were scanned).
      *
-     * @return a collection of known classes
+     * @return immutable collection of known classes, never {@code null}
      */
     Collection<ClassInfo> getKnownClasses();
 
     /**
-     * Gets the class (or interface, or annotation) that was scanned during the
-     * indexing phase.
+     * Returns the class (or enum, record, interface, annotation) with given name.
+     * Returns {@code null} if class with given name is not present in the index.
      *
      * @param className the name of the class
-     * @return information about the class or null if it is not known
+     * @return information about the class or {@code null} if it is not known
      */
     ClassInfo getClassByName(DotName className);
 
     /**
-     * Gets the class (or interface, or annotation) that was scanned during the
-     * indexing phase.
+     * Returns the class (or enum, record, interface, annotation) with given name.
+     * Returns {@code null} if class with given name is not present in the index.
      *
      * @param className the name of the class
-     * @return information about the class or null if it is not known
+     * @return information about the class or {@code null} if it is not known
      */
     default ClassInfo getClassByName(String className) {
         return getClassByName(DotName.createSimple(className));
     }
 
     /**
-     * Gets the class (or interface, or annotation) that was scanned during the
-     * indexing phase.
+     * Returns the class (or enum, record, interface, annotation) with given name ({@code clazz.getName()}).
+     * Returns {@code null} if class with given name is not present in the index.
      *
      * @param clazz the class
-     * @return information about the class or null if it is not known
+     * @return information about the class or {@code null} if it is not known
      */
     default ClassInfo getClassByName(Class<?> clazz) {
         return getClassByName(DotName.createSimple(clazz.getName()));
     }
 
     /**
-     * Gets all known direct subclasses of the specified class. A known direct
-     * subclass is one which was found during the scanning process; however, this is
-     * often not the complete universe of subclasses, since typically indexes are
-     * constructed per jar. It is expected that several indexes will need to be searched
-     * when analyzing a jar that is a part of a complex multi-module/classloader
-     * environment (like an EE application server).
+     * Returns all known direct subclasses of the given class. Indirect subclasses
+     * are <em>not</em> returned.
      * <p>
-     * Note that this will only pick up direct subclasses of the class. It will not
-     * pick up subclasses of subclasses.
-     * <p>
-     * Also note that interfaces are considered direct subclasses of {@code java.lang.Object}.
+     * Note that interfaces are considered direct subclasses of {@code java.lang.Object}.
      *
-     * @param className the super class of the desired subclasses
-     * @return a non-null list of all known subclasses of className
+     * @param className the class
+     * @return an immutable collection of known direct subclasses of given class, never {@code null}
      */
     Collection<ClassInfo> getKnownDirectSubclasses(DotName className);
 
     /**
-     * Gets all known direct subclasses of the specified class. A known direct
-     * subclass is one which was found during the scanning process; however, this is
-     * often not the complete universe of subclasses, since typically indexes are
-     * constructed per jar. It is expected that several indexes will need to be searched
-     * when analyzing a jar that is a part of a complex multi-module/classloader
-     * environment (like an EE application server).
+     * Returns all known direct subclasses of the given class. Indirect subclasses
+     * are <em>not</em> returned.
      * <p>
-     * Note that this will only pick up direct subclasses of the class. It will not
-     * pick up subclasses of subclasses.
-     * <p>
-     * Also note that interfaces are considered direct subclasses of {@code java.lang.Object}.
+     * Note that interfaces are considered direct subclasses of {@code java.lang.Object}.
      *
-     * @param className the super class of the desired subclasses
-     * @return a non-null list of all known subclasses of className
+     * @param className the class
+     * @return an immutable collection of known direct subclasses of given class, never {@code null}
      */
     default Collection<ClassInfo> getKnownDirectSubclasses(String className) {
         return getKnownDirectSubclasses(DotName.createSimple(className));
     }
 
     /**
-     * Gets all known direct subclasses of the specified class. A known direct
-     * subclass is one which was found during the scanning process; however, this is
-     * often not the complete universe of subclasses, since typically indexes are
-     * constructed per jar. It is expected that several indexes will need to be searched
-     * when analyzing a jar that is a part of a complex multi-module/classloader
-     * environment (like an EE application server).
+     * Returns all known direct subclasses of the given class. Indirect subclasses
+     * are <em>not</em> returned.
      * <p>
-     * Note that this will only pick up direct subclasses of the class. It will not
-     * pick up subclasses of subclasses.
-     * <p>
-     * Also note that interfaces are considered direct subclasses of {@code java.lang.Object}.
+     * Note that interfaces are considered direct subclasses of {@code java.lang.Object}.
      *
-     * @param clazz the super class of the desired subclasses
-     * @return a non-null list of all known subclasses of className
+     * @param clazz the class
+     * @return an immutable collection of known direct subclasses of given class, never {@code null}
      */
     default Collection<ClassInfo> getKnownDirectSubclasses(Class<?> clazz) {
         return getKnownDirectSubclasses(DotName.createSimple(clazz.getName()));
     }
 
     /**
-     * Returns all known (including non-direct) subclasses of the given class.
-     * I.e., returns all known classes that are assignable to the given class.
+     * Returns all known subclasses of the given class, direct and indirect.
+     * In other words, all classes that are assignable to the given class.
      *
-     * @param className The class
-     *
-     * @return All known subclasses
+     * @param className the class
+     * @return immutable collection of all known subclasses of given class, never {@code null}
      */
     Collection<ClassInfo> getAllKnownSubclasses(final DotName className);
 
     /**
-     * Returns all known (including non-direct) subclasses of the given class.
-     * I.e., returns all known classes that are assignable to the given class.
+     * Returns all known subclasses of the given class, direct and indirect.
+     * In other words, all classes that are assignable to the given class.
      *
-     * @param className The class
-     *
-     * @return All known subclasses
+     * @param className the class
+     * @return immutable collection of all known subclasses of given class, never {@code null}
      */
     default Collection<ClassInfo> getAllKnownSubclasses(final String className) {
         return getAllKnownSubclasses(DotName.createSimple(className));
     }
 
     /**
-     * Returns all known (including non-direct) subclasses of the given class.
-     * I.e., returns all known classes that are assignable to the given class.
+     * Returns all known subclasses of the given class, direct and indirect.
+     * In other words, all classes that are assignable to the given class.
      *
-     * @param clazz The class
-     *
-     * @return All known subclasses
+     * @param clazz the class
+     * @return immutable collection of all known subclasses of given class, never {@code null}
      */
     default Collection<ClassInfo> getAllKnownSubclasses(final Class<?> clazz) {
         return getAllKnownSubclasses(DotName.createSimple(clazz.getName()));
     }
 
     /**
-     * Gets all known direct subinterfaces of the specified interface. A known direct
-     * subinterface is one which was found during the scanning process; however, this is
-     * often not the complete universe of subinterfaces, since typically indexes are
-     * constructed per jar. It is expected that several indexes will need to be searched
-     * when analyzing a jar that is a part of a complex multi-module/classloader
-     * environment (like an EE application server).
-     * <p>
-     * Note that this will only pick up direct subinterfaces of the interface. It will not
-     * pick up subinterfaces of subinterfaces.
+     * Returns all known direct subinterfaces of the given interface. Indirect subinterfaces
+     * are <em>not</em> returned.
      *
-     * @param interfaceName the super interface of the desired subinterfaces
-     * @return a non-null list of all known subinterfaces of interfaceName
+     * @param interfaceName the interface
+     * @return immutable collection of all known subinterfaces of given interface, never {@code null}
      * @since 3.0
      */
     Collection<ClassInfo> getKnownDirectSubinterfaces(DotName interfaceName);
 
     /**
-     * Gets all known direct subinterfaces of the specified interface. A known direct
-     * subinterface is one which was found during the scanning process; however, this is
-     * often not the complete universe of subinterfaces, since typically indexes are
-     * constructed per jar. It is expected that several indexes will need to be searched
-     * when analyzing a jar that is a part of a complex multi-module/classloader
-     * environment (like an EE application server).
-     * <p>
-     * Note that this will only pick up direct subinterfaces of the interface. It will not
-     * pick up subinterfaces of subinterfaces.
+     * Returns all known direct subinterfaces of the given interface. Indirect subinterfaces
+     * are <em>not</em> returned.
      *
-     * @param interfaceName the super interface of the desired subinterfaces
-     * @return a non-null list of all known subinterfaces of interfaceName
+     * @param interfaceName the interface
+     * @return immutable collection of all known subinterfaces of given interface, never {@code null}
      * @since 3.0
      */
     default Collection<ClassInfo> getKnownDirectSubinterfaces(String interfaceName) {
@@ -205,18 +167,11 @@ public interface IndexView {
     }
 
     /**
-     * Gets all known direct subinterfaces of the specified interface. A known direct
-     * subinterface is one which was found during the scanning process; however, this is
-     * often not the complete universe of subinterfaces, since typically indexes are
-     * constructed per jar. It is expected that several indexes will need to be searched
-     * when analyzing a jar that is a part of a complex multi-module/classloader
-     * environment (like an EE application server).
-     * <p>
-     * Note that this will only pick up direct subinterfaces of the interface. It will not
-     * pick up subinterfaces of subinterfaces.
+     * Returns all known direct subinterfaces of the given interface. Indirect subinterfaces
+     * are <em>not</em> returned.
      *
-     * @param interfaceClass the super interface of the desired subinterfaces
-     * @return a non-null list of all known subinterfaces of interfaceClass
+     * @param interfaceClass the interface
+     * @return immutable collection of all known subinterfaces of given interface, never {@code null}
      * @since 3.0
      */
     default Collection<ClassInfo> getKnownDirectSubinterfaces(Class<?> interfaceClass) {
@@ -224,18 +179,18 @@ public interface IndexView {
     }
 
     /**
-     * Returns all known interfaces that extend the given interface, directly and indirectly.
-     * I.e., returns every interface in the index that is assignable to the given interface.
+     * Returns all known subinterfaces of the given interface, direct and indirect.
+     * In other words, all interfaces that are assignable to the given interface.
      *
-     * @param interfaceName The interface
-     * @return all known subinterfaces
+     * @param interfaceName the interface
+     * @return immutable collection of all known subinterfaces of given interface, never {@code null}
      * @since 3.0
      */
     Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName);
 
     /**
      * Returns all known interfaces that extend the given interface, directly and indirectly.
-     * I.e., returns every interface in the index that is assignable to the given interface.
+     * In other words, all interfaces in the index that are assignable to the given interface.
      *
      * @param interfaceName The interface
      * @return all known subinterfaces
@@ -246,15 +201,98 @@ public interface IndexView {
     }
 
     /**
-     * Returns all known interfaces that extend the given interface, directly and indirectly.
-     * I.e., returns every interface in the index that is assignable to the given interface.
+     * Returns all known subinterfaces of the given interface, direct and indirect.
+     * In other words, all interfaces that are assignable to the given interface.
      *
-     * @param interfaceClass The interface
-     * @return all known subinterfaces
+     * @param interfaceClass the interface
+     * @return immutable collection of all known subinterfaces of given interface, never {@code null}
      * @since 3.0
      */
     default Collection<ClassInfo> getAllKnownSubinterfaces(Class<?> interfaceClass) {
         return getAllKnownSubinterfaces(DotName.createSimple(interfaceClass.getName()));
+    }
+
+    /**
+     * Returns all known classes that directly implement the given interface. Classes that
+     * do not directly implement the given interface but do directly implement subinterfaces
+     * are <em>not</em> returned. Subclasses of classes that directly implement the given
+     * interface are <em>not</em> returned either.
+     * <p>
+     * Note that unlike {@link #getKnownDirectImplementors(DotName)}, this method
+     * does <em>NOT</em> return direct subinterfaces of the given interface, which
+     * is typically what you expect when you call this method.
+     *
+     * @param interfaceName the interface
+     * @return immutable collection of all known direct implementations of the interface, never {@code null}
+     */
+    Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName);
+
+    /**
+     * Returns all known classes that directly implement the given interface. Classes that
+     * do not directly implement the given interface but do directly implement subinterfaces
+     * are <em>not</em> returned. Subclasses of classes that directly implement the given
+     * interface are <em>not</em> returned either.
+     * <p>
+     * Note that unlike {@link #getKnownDirectImplementors(DotName)}, this method
+     * does <em>NOT</em> return direct subinterfaces of the given interface, which
+     * is typically what you expect when you call this method.
+     *
+     * @param interfaceName the interface
+     * @return immutable collection of all known direct implementations of the interface, never {@code null}
+     */
+    default Collection<ClassInfo> getKnownDirectImplementations(String interfaceName) {
+        return getKnownDirectImplementations(DotName.createSimple(interfaceName));
+    }
+
+    /**
+     * Returns all known classes that directly implement the given interface. Classes that
+     * do not directly implement the given interface but do directly implement subinterfaces
+     * are <em>not</em> returned. Subclasses of classes that directly implement the given
+     * interface are <em>not</em> returned either.
+     * <p>
+     * Note that unlike {@link #getKnownDirectImplementors(DotName)}, this method
+     * does <em>NOT</em> return direct subinterfaces of the given interface, which
+     * is typically what you expect when you call this method.
+     *
+     * @param interfaceClass the interface
+     * @return immutable collection of all known direct implementations of the interface, never {@code null}
+     */
+    default Collection<ClassInfo> getKnownDirectImplementations(Class<?> interfaceClass) {
+        return getKnownDirectImplementations(DotName.createSimple(interfaceClass.getName()));
+    }
+
+    /**
+     * Returns all known classes that implement the given interface, directly and indirectly.
+     * That is, all classes that implement the interface and its subinterfaces, as well as
+     * all their subclasses. In other words, all classes that are assignable to the interface.
+     *
+     * @param interfaceName the interface
+     * @return immutable collection of all known implementations of the interface, never {@code null}
+     */
+    Collection<ClassInfo> getAllKnownImplementations(DotName interfaceName);
+
+    /**
+     * Returns all known classes that implement the given interface, directly and indirectly.
+     * That is, all classes that implement the interface and its subinterfaces, as well as
+     * all their subclasses. In other words, all classes that are assignable to the interface.
+     *
+     * @param interfaceName the interface
+     * @return immutable collection of all known implementations of the interface, never {@code null}
+     */
+    default Collection<ClassInfo> getAllKnownImplementations(String interfaceName) {
+        return getAllKnownImplementations(DotName.createSimple(interfaceName));
+    }
+
+    /**
+     * Returns all known classes that implement the given interface, directly and indirectly.
+     * That is, all classes that implement the interface and its subinterfaces, as well as
+     * all their subclasses. In other words, all classes that are assignable to the interface.
+     *
+     * @param interfaceClass the interface
+     * @return immutable collection of all known implementations of the interface, never {@code null}
+     */
+    default Collection<ClassInfo> getAllKnownImplementations(Class<?> interfaceClass) {
+        return getAllKnownImplementations(DotName.createSimple(interfaceClass.getName()));
     }
 
     /**
@@ -274,6 +312,7 @@ public interface IndexView {
      * @param interfaceName The interface
      * @return All known direct implementors of the interface
      */
+    @Deprecated
     Collection<ClassInfo> getKnownDirectImplementors(DotName interfaceName);
 
     /**
@@ -293,6 +332,7 @@ public interface IndexView {
      * @param interfaceName The interface
      * @return All known direct implementors of the interface
      */
+    @Deprecated
     default Collection<ClassInfo> getKnownDirectImplementors(String interfaceName) {
         return getKnownDirectImplementors(DotName.createSimple(interfaceName));
     }
@@ -314,6 +354,7 @@ public interface IndexView {
      * @param interfaceClass The interface
      * @return All known direct implementors of the interface
      */
+    @Deprecated
     default Collection<ClassInfo> getKnownDirectImplementors(Class<?> interfaceClass) {
         return getKnownDirectImplementors(DotName.createSimple(interfaceClass.getName()));
     }
@@ -330,6 +371,7 @@ public interface IndexView {
      * @param interfaceName The interface
      * @return All known implementors of the interface
      */
+    @Deprecated
     Collection<ClassInfo> getAllKnownImplementors(final DotName interfaceName);
 
     /**
@@ -344,6 +386,7 @@ public interface IndexView {
      * @param interfaceName The interface
      * @return All known implementors of the interface
      */
+    @Deprecated
     default Collection<ClassInfo> getAllKnownImplementors(final String interfaceName) {
         return getAllKnownImplementors(DotName.createSimple(interfaceName));
     }
@@ -360,6 +403,7 @@ public interface IndexView {
      * @param interfaceClass The interface
      * @return All known implementors of the interface
      */
+    @Deprecated
     default Collection<ClassInfo> getAllKnownImplementors(final Class<?> interfaceClass) {
         return getAllKnownImplementors(DotName.createSimple(interfaceClass.getName()));
     }
@@ -370,7 +414,7 @@ public interface IndexView {
      * field, method, parameter, and class.
      *
      * @param annotationName the name of the annotation to look for
-     * @return a non-null list of annotation instances
+     * @return immutable collection of annotation instances, never {@code null}
      */
     Collection<AnnotationInstance> getAnnotations(DotName annotationName);
 
@@ -380,7 +424,7 @@ public interface IndexView {
      * field, method, parameter, and class.
      *
      * @param annotationName the name of the annotation to look for
-     * @return a non-null list of annotation instances
+     * @return immutable collection of annotation instances, never {@code null}
      */
     default Collection<AnnotationInstance> getAnnotations(String annotationName) {
         return getAnnotations(DotName.createSimple(annotationName));
@@ -392,7 +436,7 @@ public interface IndexView {
      * field, method, parameter, and class.
      *
      * @param annotationType the type of the annotation to look for
-     * @return a non-null list of annotation instances
+     * @return immutable collection of annotation instances, never {@code null}
      */
     default Collection<AnnotationInstance> getAnnotations(Class<?> annotationType) {
         return getAnnotations(DotName.createSimple(annotationType.getName()));
@@ -405,7 +449,7 @@ public interface IndexView {
      *
      * @param annotationName the name of the repeatable annotation
      * @param index the index containing the annotation class
-     * @return a non-null list of annotation instances
+     * @return immutable collection of annotation instances, never {@code null}
      * @throws IllegalArgumentException If the index does not contain the annotation definition or if it does not represent
      *         an annotation type
      */
@@ -418,7 +462,7 @@ public interface IndexView {
      *
      * @param annotationName the name of the repeatable annotation
      * @param index the index containing the annotation class
-     * @return a non-null list of annotation instances
+     * @return immutable collection of annotation instances, never {@code null}
      * @throws IllegalArgumentException If the index does not contain the annotation definition or if it does not represent
      *         an annotation type
      */
@@ -433,7 +477,7 @@ public interface IndexView {
      *
      * @param annotationType the name of the repeatable annotation
      * @param index the index containing the annotation class
-     * @return a non-null list of annotation instances
+     * @return immutable collection of annotation instances, never {@code null}
      * @throws IllegalArgumentException If the index does not contain the annotation definition or if it does not represent
      *         an annotation type
      */
@@ -444,7 +488,7 @@ public interface IndexView {
     /**
      * Gets all known modules by this index (those which were scanned).
      *
-     * @return a collection of known modules
+     * @return immutable collection of known modules, never {@code null}
      */
     Collection<ModuleInfo> getKnownModules();
 
@@ -452,7 +496,7 @@ public interface IndexView {
      * Gets the module that was scanned during the indexing phase.
      *
      * @param moduleName the name of the module
-     * @return information about the module or null if it is not known
+     * @return information about the module or {@code null} if it is not known
      */
     ModuleInfo getModuleByName(DotName moduleName);
 
@@ -460,7 +504,7 @@ public interface IndexView {
      * Gets the module that was scanned during the indexing phase.
      *
      * @param moduleName the name of the module
-     * @return information about the module or null if it is not known
+     * @return information about the module or {@code null} if it is not known
      */
     default ModuleInfo getModuleByName(String moduleName) {
         return getModuleByName(DotName.createSimple(moduleName));
@@ -481,7 +525,7 @@ public interface IndexView {
      * </ul>
      *
      * @param className the name of the class to look for
-     * @return a non-null list of classes that use the specified class
+     * @return immutable collection of classes that use the specified class, never {@code null}
      */
     Collection<ClassInfo> getKnownUsers(DotName className);
 
@@ -500,7 +544,7 @@ public interface IndexView {
      * </ul>
      *
      * @param className the name of the class to look for
-     * @return a non-null list of classes that use the specified class
+     * @return immutable collection of classes that use the specified class, never {@code null}
      */
     default Collection<ClassInfo> getKnownUsers(String className) {
         return getKnownUsers(DotName.createSimple(className));
@@ -521,7 +565,7 @@ public interface IndexView {
      * </ul>
      *
      * @param clazz the class to look for
-     * @return a non-null list of classes that use the specified class
+     * @return immutable collection of classes that use the specified class, never {@code null}
      */
     default Collection<ClassInfo> getKnownUsers(Class<?> clazz) {
         return getKnownUsers(DotName.createSimple(clazz.getName()));

--- a/core/src/main/java/org/jboss/jandex/StackedIndex.java
+++ b/core/src/main/java/org/jboss/jandex/StackedIndex.java
@@ -183,6 +183,26 @@ public final class StackedIndex implements IndexView {
     }
 
     @Override
+    public Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName) {
+        List<ClassInfo> result = new ArrayList<>();
+        Set<DotName> seen = new HashSet<>();
+        for (IndexView idx : stack) {
+            for (ClassInfo clazz : idx.getKnownDirectImplementations(interfaceName)) {
+                if (seen.add(clazz.name())) {
+                    result.add(clazz);
+                }
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public Collection<ClassInfo> getAllKnownImplementations(DotName interfaceName) {
+        // no difference here
+        return getAllKnownImplementors(interfaceName);
+    }
+
+    @Override
     public Collection<ClassInfo> getKnownDirectImplementors(DotName interfaceName) {
         List<ClassInfo> result = new ArrayList<>();
         Set<DotName> seen = new HashSet<>();

--- a/core/src/test/java/org/jboss/jandex/test/AnnotationOverlayTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/AnnotationOverlayTest.java
@@ -397,6 +397,16 @@ public class AnnotationOverlayTest {
         }
 
         @Override
+        public Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName) {
+            return delegate.getKnownDirectImplementations(interfaceName);
+        }
+
+        @Override
+        public Collection<ClassInfo> getAllKnownImplementations(DotName interfaceName) {
+            return delegate.getAllKnownImplementations(interfaceName);
+        }
+
+        @Override
         public Collection<ClassInfo> getKnownDirectImplementors(DotName interfaceName) {
             return delegate.getKnownDirectImplementors(interfaceName);
         }

--- a/core/src/test/java/org/jboss/jandex/test/IndexNavigationTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/IndexNavigationTest.java
@@ -136,6 +136,23 @@ public class IndexNavigationTest {
         assertCollection(index.getAllKnownSubinterfaces(IChild.class), IGrandchild1.class, IGrandchild1.class,
                 IGrandchild2.class);
 
+        assertCollection(index.getKnownDirectImplementations(IGrandparent.class), CGrandparent.class);
+        assertCollection(index.getKnownDirectImplementations(IParent.class), CParent.class);
+        assertCollection(index.getKnownDirectImplementations(IChild.class), CChild.class, CChild.class);
+        assertCollection(index.getKnownDirectImplementations(ISibling.class), CSibling.class);
+        assertCollection(index.getKnownDirectImplementations(IGrandchild1.class), CGrandchild1.class, CGrandchild1.class);
+        assertCollection(index.getKnownDirectImplementations(IGrandchild2.class), CGrandchild2.class);
+
+        assertCollection(index.getAllKnownImplementations(IGrandparent.class), CGrandparent.class, CParent.class, CChild.class,
+                CGrandchild1.class, CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownImplementations(IParent.class), CParent.class, CChild.class, CGrandchild1.class,
+                CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
+        // doesn't behave as expected, but the behavior is actually not defined
+        //assertCollection(index.getAllKnownImplementations(IChild.class), CChild.class, CGrandchild1.class, CChild.class, CGrandchild1.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownImplementations(ISibling.class), CSibling.class);
+        assertCollection(index.getAllKnownImplementations(IGrandchild1.class), CGrandchild1.class);
+        assertCollection(index.getAllKnownImplementations(IGrandchild2.class), CGrandchild2.class);
+
         assertCollection(index.getKnownDirectImplementors(IGrandparent.class), CGrandparent.class, IParent.class);
         assertCollection(index.getKnownDirectImplementors(IParent.class), IChild.class, CParent.class, IChild.class,
                 ISibling.class);
@@ -193,6 +210,8 @@ public class IndexNavigationTest {
         testAllSubclasses(index);
         testDirectSubinterfaces(index);
         testAllSubinterfaces(index);
+        testDirectImplementations(index);
+        testAllImplementations(index);
         testDirectImplementors(index);
         testAllImplementors(index);
         testClassesInPackage(index);
@@ -267,6 +286,40 @@ public class IndexNavigationTest {
         assertCollection(index.getAllKnownSubinterfaces(CSibling.class));
         assertCollection(index.getAllKnownSubinterfaces(CGrandchild1.class));
         assertCollection(index.getAllKnownSubinterfaces(CGrandchild2.class));
+    }
+
+    private void testDirectImplementations(IndexView index) {
+        assertCollection(index.getKnownDirectImplementations(Object.class));
+        assertCollection(index.getKnownDirectImplementations(IGrandparent.class), CGrandparent.class);
+        assertCollection(index.getKnownDirectImplementations(IParent.class), CParent.class);
+        assertCollection(index.getKnownDirectImplementations(IChild.class), CChild.class);
+        assertCollection(index.getKnownDirectImplementations(ISibling.class), CSibling.class);
+        assertCollection(index.getKnownDirectImplementations(IGrandchild1.class), CGrandchild1.class);
+        assertCollection(index.getKnownDirectImplementations(IGrandchild2.class), CGrandchild2.class);
+        assertCollection(index.getKnownDirectImplementations(CGrandparent.class));
+        assertCollection(index.getKnownDirectImplementations(CParent.class));
+        assertCollection(index.getKnownDirectImplementations(CChild.class));
+        assertCollection(index.getKnownDirectImplementations(CSibling.class));
+        assertCollection(index.getKnownDirectImplementations(CGrandchild1.class));
+        assertCollection(index.getKnownDirectImplementations(CGrandchild2.class));
+    }
+
+    private void testAllImplementations(IndexView index) {
+        assertCollection(index.getAllKnownImplementations(Object.class));
+        assertCollection(index.getAllKnownImplementations(IGrandparent.class), CGrandparent.class, CParent.class, CChild.class,
+                CSibling.class, CGrandchild1.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownImplementations(IParent.class), CParent.class, CChild.class, CSibling.class,
+                CGrandchild1.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownImplementations(IChild.class), CChild.class, CGrandchild1.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownImplementations(ISibling.class), CSibling.class);
+        assertCollection(index.getAllKnownImplementations(IGrandchild1.class), CGrandchild1.class);
+        assertCollection(index.getAllKnownImplementations(IGrandchild2.class), CGrandchild2.class);
+        assertCollection(index.getAllKnownImplementations(CGrandparent.class));
+        assertCollection(index.getAllKnownImplementations(CParent.class));
+        assertCollection(index.getAllKnownImplementations(CChild.class));
+        assertCollection(index.getAllKnownImplementations(CSibling.class));
+        assertCollection(index.getAllKnownImplementations(CGrandchild1.class));
+        assertCollection(index.getAllKnownImplementations(CGrandchild2.class));
     }
 
     private void testDirectImplementors(IndexView index) {

--- a/core/src/test/java/org/jboss/jandex/test/SubtypesLookupTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SubtypesLookupTest.java
@@ -58,52 +58,66 @@ public class SubtypesLookupTest {
     private void test(Index index) {
         check(index.getKnownDirectSubclasses(Foo.class)); // empty
         check(index.getKnownDirectSubinterfaces(Foo.class), "Bar");
+        check(index.getKnownDirectImplementations(Foo.class), "A");
         check(index.getKnownDirectImplementors(Foo.class), "A", "Bar"); // Bar is intentional
         check(index.getAllKnownSubclasses(Foo.class)); // empty
         check(index.getAllKnownSubinterfaces(Foo.class), "Bar", "Baz");
+        check(index.getAllKnownImplementations(Foo.class), "A", "B", "C", "D", "E", "F");
         check(index.getAllKnownImplementors(Foo.class), "A", "B", "C", "D", "E", "F");
 
         check(index.getKnownDirectSubclasses(Bar.class)); // empty
         check(index.getKnownDirectSubinterfaces(Bar.class), "Baz");
+        check(index.getKnownDirectImplementations(Bar.class), "C", "E");
         check(index.getKnownDirectImplementors(Bar.class), "C", "E", "Baz"); // Baz is intentional
         check(index.getAllKnownSubclasses(Bar.class)); // empty
         check(index.getAllKnownSubinterfaces(Bar.class), "Baz");
+        check(index.getAllKnownImplementations(Bar.class), "C", "D", "E", "F");
         check(index.getAllKnownImplementors(Bar.class), "C", "D", "E", "F");
 
         check(index.getKnownDirectSubclasses(Baz.class)); // empty
         check(index.getKnownDirectSubinterfaces(Baz.class)); // empty
+        check(index.getKnownDirectImplementations(Baz.class), "D", "F");
         check(index.getKnownDirectImplementors(Baz.class), "D", "F");
         check(index.getAllKnownSubclasses(Baz.class)); // empty
         check(index.getAllKnownSubinterfaces(Baz.class)); // empty
+        check(index.getAllKnownImplementations(Baz.class), "D", "F");
         check(index.getAllKnownImplementors(Baz.class), "D", "F");
 
         check(index.getKnownDirectSubclasses(Quux.class)); // empty
         check(index.getKnownDirectSubinterfaces(Quux.class)); // empty
+        check(index.getKnownDirectImplementations(Quux.class), "B", "F");
         check(index.getKnownDirectImplementors(Quux.class), "B", "F");
         check(index.getAllKnownSubclasses(Quux.class)); // empty
         check(index.getAllKnownSubinterfaces(Quux.class)); // empty
+        check(index.getAllKnownImplementations(Quux.class), "B", "C", "D", "F");
         check(index.getAllKnownImplementors(Quux.class), "B", "C", "D", "F");
 
         check(index.getKnownDirectSubclasses(A.class), "B");
         check(index.getKnownDirectSubinterfaces(A.class)); // empty
+        check(index.getKnownDirectImplementations(A.class)); // empty
         check(index.getKnownDirectImplementors(A.class)); // empty
         check(index.getAllKnownSubclasses(A.class), "B", "C", "D");
         check(index.getAllKnownSubinterfaces(A.class)); // empty
+        check(index.getAllKnownImplementations(A.class)); // empty
         check(index.getAllKnownImplementors(A.class)); // empty
 
         check(index.getKnownDirectSubclasses(B.class), "C", "D");
         check(index.getKnownDirectSubinterfaces(B.class)); // empty
+        check(index.getKnownDirectImplementations(B.class)); // empty
         check(index.getKnownDirectImplementors(B.class)); // empty
         check(index.getAllKnownSubclasses(B.class), "C", "D");
         check(index.getAllKnownSubinterfaces(B.class)); // empty
+        check(index.getAllKnownImplementations(B.class)); // empty
         check(index.getAllKnownImplementors(B.class)); // empty
 
         for (Class<?> clazz : Arrays.asList(C.class, D.class, E.class, F.class, Z.class)) {
             check(index.getKnownDirectSubclasses(clazz)); // empty
             check(index.getKnownDirectSubinterfaces(clazz)); // empty
+            check(index.getKnownDirectImplementations(clazz)); // empty
             check(index.getKnownDirectImplementors(clazz)); // empty
             check(index.getAllKnownSubclasses(clazz)); // empty
             check(index.getAllKnownSubinterfaces(clazz)); // empty
+            check(index.getAllKnownImplementations(clazz)); // empty
             check(index.getAllKnownImplementors(clazz)); // empty
         }
     }


### PR DESCRIPTION
The `getKnownDirectImplementations()` method is different to `getKnownDirectImplementors()` in that it doesn't return direct subinterfaces of the given interface.

The `getAllKnownImplementations()` method is not different to `getAllKnownImplementors()`, it only exists for symmetry.

The previous methods, `getKnownDirectImplementors()` and `getAllKnownImplementors()`, are deprecated now.