### PR TITLE
add missing deprecation notices

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -344,6 +344,7 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
      * performs a defensive copy, so {@link #interfaceNames()} should be used instead.
      *
      * @return an array of interface names implemented by this class
+     * @deprecated use {@link #interfaceNames()}
      */
     @Deprecated
     public final DotName[] interfaces() {

--- a/core/src/main/java/org/jboss/jandex/IndexView.java
+++ b/core/src/main/java/org/jboss/jandex/IndexView.java
@@ -311,6 +311,7 @@ public interface IndexView {
      *
      * @param interfaceName The interface
      * @return All known direct implementors of the interface
+     * @deprecated use {@link #getKnownDirectImplementations(DotName)}
      */
     @Deprecated
     Collection<ClassInfo> getKnownDirectImplementors(DotName interfaceName);
@@ -331,6 +332,7 @@ public interface IndexView {
      *
      * @param interfaceName The interface
      * @return All known direct implementors of the interface
+     * @deprecated use {@link #getKnownDirectImplementations(String)}
      */
     @Deprecated
     default Collection<ClassInfo> getKnownDirectImplementors(String interfaceName) {
@@ -353,6 +355,7 @@ public interface IndexView {
      *
      * @param interfaceClass The interface
      * @return All known direct implementors of the interface
+     * @deprecated use {@link #getKnownDirectImplementations(Class)}
      */
     @Deprecated
     default Collection<ClassInfo> getKnownDirectImplementors(Class<?> interfaceClass) {
@@ -370,6 +373,7 @@ public interface IndexView {
      *
      * @param interfaceName The interface
      * @return All known implementors of the interface
+     * @deprecated use {@link #getAllKnownImplementations(DotName)}
      */
     @Deprecated
     Collection<ClassInfo> getAllKnownImplementors(final DotName interfaceName);
@@ -385,6 +389,7 @@ public interface IndexView {
      *
      * @param interfaceName The interface
      * @return All known implementors of the interface
+     * @deprecated use {@link #getAllKnownImplementations(String)}
      */
     @Deprecated
     default Collection<ClassInfo> getAllKnownImplementors(final String interfaceName) {
@@ -402,6 +407,7 @@ public interface IndexView {
      *
      * @param interfaceClass The interface
      * @return All known implementors of the interface
+     * @deprecated use {@link #getAllKnownImplementations(Class)}
      */
     @Deprecated
     default Collection<ClassInfo> getAllKnownImplementors(final Class<?> interfaceClass) {

--- a/core/src/main/java/org/jboss/jandex/IndexWriter.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriter.java
@@ -74,6 +74,7 @@ public final class IndexWriter {
      * @param version the index file version
      * @return the number of bytes written to the stream
      * @throws IOException if any i/o error occurs
+     * @deprecated use {@link #write(Index, int)}
      */
     @Deprecated
     public int write(Index index, byte version) throws IOException {

--- a/core/src/main/java/org/jboss/jandex/WildcardType.java
+++ b/core/src/main/java/org/jboss/jandex/WildcardType.java
@@ -42,7 +42,7 @@ public class WildcardType extends Type {
      * @return the new instance
      *
      * @since 2.1
-     * @deprecated use {@link #createUpperBound(Type)} or {@link #createLowerBound(Type)} instead
+     * @deprecated use {@link #createUpperBound(Type)} or {@link #createLowerBound(Type)}
      */
     @Deprecated
     public static WildcardType create(Type bound, boolean isExtends) {


### PR DESCRIPTION
All `@Deprecated` program elements that are publicly accessible now have a `@deprecated` section in their javadoc.

Fixes #519