### PR TITLE
add module descriptor

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,7 +89,6 @@
                             <mainClass>org.jboss.jandex.Main</mainClass>
                         </manifest>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.jboss.jandex</Automatic-Module-Name>
                             <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
@@ -109,6 +108,24 @@
                         <_nouses>true</_nouses>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-module-info</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <module>
+                                <moduleInfoFile>src/main/module/module-info.java</moduleInfoFile>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jboss.bridger</groupId>

--- a/core/src/main/module/module-info.java
+++ b/core/src/main/module/module-info.java
@@ -1,0 +1,6 @@
+module org.jboss.jandex {
+    exports org.jboss.jandex;
+
+    // Ant does not have module descriptors
+    // requires static org.apache.tools.ant;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <version.maven-invoker-plugin>3.9.0</version.maven-invoker-plugin>
         <version.maven-plugin-tools>3.15.1</version.maven-plugin-tools>
         <version.maven-shade-plugin>3.5.1</version.maven-shade-plugin>
+        <version.moditect>1.2.2.Final</version.moditect>
         <version.nexus-staging-maven-plugin>1.7.0</version.nexus-staging-maven-plugin>
         <version.mvn-jlink-wrapper>1.2.4</version.mvn-jlink-wrapper>
         <version.plexus-compiler-eclipse>2.15.0</version.plexus-compiler-eclipse>
@@ -119,6 +120,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.maven-compiler-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.moditect</groupId>
+                    <artifactId>moditect-maven-plugin</artifactId>
+                    <version>${version.moditect}</version>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Since Jandex is still a Java 8 project, we cannot add `module-info.java` to `src/main/java` and build it using javac. Instead, we put the module descriptor into a separate directory (`src/main/module`) and use Moditect to build it (into `module-info.class`).

Fixes #514