### PR TITLE
fix ClassInfo.simpleName()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -1200,7 +1200,14 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
      * @return the simple name of a top-level, member or local class, or {@code null} if this is an anonymous class
      */
     public String simpleName() {
-        return nestingInfo != null ? nestingInfo.simpleName : name.local();
+        // it would be enough to always call `name.withoutPackagePrefix()`, but we want to avoid needless allocations
+        if (nestingInfo != null) {
+            return nestingInfo.simpleName;
+        } else if (name.isComponentized() && !name.isInner()) {
+            return name.local();
+        } else {
+            return name.withoutPackagePrefix();
+        }
     }
 
     String nestingSimpleName() {

--- a/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -74,6 +74,9 @@ import org.jboss.jandex.Type;
 import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
+class Top$Level {
+}
+
 public class BasicTestCase {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface FieldAnnotation {
@@ -219,6 +222,9 @@ public class BasicTestCase {
     }
 
     public class NestedD implements Serializable {
+    }
+
+    public static class Nested$E {
     }
 
     public static class NoEnclosureAnonTest {
@@ -456,18 +462,17 @@ public class BasicTestCase {
     public void testSimpleName() throws IOException {
         class MyLocal {
         }
-        assertEquals("NestedC", getIndexForClasses(NestedC.class)
-                .getClassByName(DotName.createSimple(NestedC.class.getName())).simpleName());
-        assertEquals("BasicTestCase", getIndexForClasses(BasicTestCase.class)
-                .getClassByName(DotName.createSimple(BasicTestCase.class.getName())).simpleName());
-        assertEquals("MyLocal", getIndexForClasses(MyLocal.class)
-                .getClassByName(DotName.createSimple(MyLocal.class.getName())).simpleName());
-        assertEquals("String", getIndexForClasses(String.class)
-                .getClassByName(DotName.createSimple(String.class.getName())).simpleName());
+        assertEquals("Top$Level", Index.singleClass(Top$Level.class).simpleName());
+        assertEquals("BasicTestCase", Index.singleClass(BasicTestCase.class).simpleName());
+        assertEquals("String", Index.singleClass(String.class).simpleName());
+        assertEquals("NestedC", Index.singleClass(NestedC.class).simpleName());
+        assertEquals("NestedD", Index.singleClass(NestedD.class).simpleName());
+        assertEquals("Nested$E", Index.singleClass(Nested$E.class).simpleName());
+        assertEquals("MyLocal", Index.singleClass(MyLocal.class).simpleName());
         // @formatter:off
         Class<?> anon = new Object() {}.getClass();
         // @formatter:on
-        assertNull(getIndexForClasses(anon).getClassByName(DotName.createSimple(anon.getName())).simpleName());
+        assertNull(Index.singleClass(anon).simpleName());
     }
 
     @Test
@@ -716,19 +721,19 @@ public class BasicTestCase {
     }
 
     private void assertHasNoArgsConstructor(Class<?> clazz, boolean result) throws IOException {
-        ClassInfo classInfo = getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        ClassInfo classInfo = Index.singleClass(clazz);
         assertNotNull(classInfo);
         assertEquals(result, classInfo.hasNoArgsConstructor());
     }
 
     private void assertFlagSet(Class<?> clazz, int flag, boolean result) throws IOException {
-        ClassInfo classInfo = getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        ClassInfo classInfo = Index.singleClass(clazz);
         assertNotNull(classInfo);
-        assertTrue((classInfo.flags() & flag) == (result ? flag : 0));
+        assertEquals(result ? flag : 0, classInfo.flags() & flag);
     }
 
     private void assertNesting(Class<?> clazz, ClassInfo.NestingType nesting, boolean result) throws IOException {
-        ClassInfo classInfo = getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        ClassInfo classInfo = Index.singleClass(clazz);
         assertNotNull(classInfo);
         if (result) {
             assertEquals(nesting, classInfo.nestingType());
@@ -737,17 +742,9 @@ public class BasicTestCase {
         }
     }
 
-    static Index getIndexForClasses(Class<?>... classes) throws IOException {
-        return Index.of(classes);
-    }
-
-    static ClassInfo getClassInfo(Class<?> clazz) throws IOException {
-        return getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
-    }
-
     @Test
     public void testClassConstantIndexing() throws IOException, URISyntaxException {
-        Index index = getIndexForClasses(DummyClass.class, ApiClass.class, ApiUser.class);
+        Index index = Index.of(DummyClass.class, ApiClass.class, ApiUser.class);
         DotName apiClassDotName = DotName.createSimple(ApiClass.class.getName());
         List<ClassInfo> users = index.getKnownUsers(apiClassDotName);
         assertEquals(2, users.size());


### PR DESCRIPTION
The `simpleName()` method used to return a wrong result in case of top-level classes with dollar `$` in their names. For example, for the following class

```java
public class Top$Level {
}
```

the `ClassInfo.simpleName()` method used to return `Level`. This commit fixes that by only calling `name.local()` in case the `name` is componentized (which it always is, so just to be sure) and is _not_ marked inner. If it is marked inner, the `simpleName()` method calls `name.withoutPackagePrefix()`.

It would be possible to call `withoutPackagePrefix()` always, but that method allocates in case of componentized names, which we want to avoid if possible.

Fixes #526