### PR TITLE
intern `EquivalenceKey`s for primitive types and class types of `java.*`

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassType.java
+++ b/core/src/main/java/org/jboss/jandex/ClassType.java
@@ -32,15 +32,15 @@ public final class ClassType extends Type {
     public static final ClassType STRING_TYPE = new ClassType(DotName.STRING_NAME);
     public static final ClassType CLASS_TYPE = new ClassType(DotName.CLASS_NAME);
 
-    public static final ClassType BYTE_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Byte"));
-    public static final ClassType CHARACTER_CLASS = new ClassType(
-            DotName.createComponentized(DotName.JAVA_LANG_NAME, "Character"));
-    public static final ClassType DOUBLE_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Double"));
-    public static final ClassType FLOAT_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Float"));
-    public static final ClassType INTEGER_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Integer"));
-    public static final ClassType LONG_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Long"));
-    public static final ClassType SHORT_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Short"));
-    public static final ClassType BOOLEAN_CLASS = new ClassType(DotName.createComponentized(DotName.JAVA_LANG_NAME, "Boolean"));
+    public static final ClassType BYTE_CLASS = new ClassType(DotName.BYTE_CLASS_NAME);
+    public static final ClassType CHARACTER_CLASS = new ClassType(DotName.CHARACTER_CLASS_NAME);
+    public static final ClassType DOUBLE_CLASS = new ClassType(DotName.DOUBLE_CLASS_NAME);
+    public static final ClassType FLOAT_CLASS = new ClassType(DotName.FLOAT_CLASS_NAME);
+    public static final ClassType INTEGER_CLASS = new ClassType(DotName.INTEGER_CLASS_NAME);
+    public static final ClassType LONG_CLASS = new ClassType(DotName.LONG_CLASS_NAME);
+    public static final ClassType SHORT_CLASS = new ClassType(DotName.SHORT_CLASS_NAME);
+    public static final ClassType BOOLEAN_CLASS = new ClassType(DotName.BOOLEAN_CLASS_NAME);
+    public static final ClassType VOID_CLASS = new ClassType(DotName.VOID_CLASS_NAME);
 
     /**
      * Create an instance of a class type with given {@code name}.

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -45,11 +45,23 @@ public final class DotName implements Comparable<DotName> {
     static final DotName JAVA_NAME;
     static final DotName JAVA_LANG_NAME;
     static final DotName JAVA_LANG_ANNOTATION_NAME;
+
     public static final DotName OBJECT_NAME;
+    public static final DotName CLASS_NAME;
     public static final DotName ENUM_NAME;
     public static final DotName RECORD_NAME;
     public static final DotName STRING_NAME;
-    public static final DotName CLASS_NAME;
+
+    public static final DotName BOOLEAN_CLASS_NAME;
+    public static final DotName BYTE_CLASS_NAME;
+    public static final DotName SHORT_CLASS_NAME;
+    public static final DotName INTEGER_CLASS_NAME;
+    public static final DotName LONG_CLASS_NAME;
+    public static final DotName FLOAT_CLASS_NAME;
+    public static final DotName DOUBLE_CLASS_NAME;
+    public static final DotName CHARACTER_CLASS_NAME;
+    public static final DotName VOID_CLASS_NAME;
+
     public static final DotName INHERITED_NAME;
     public static final DotName REPEATABLE_NAME;
     public static final DotName RETENTION_NAME;
@@ -61,17 +73,29 @@ public final class DotName implements Comparable<DotName> {
     private final boolean innerClass;
 
     static {
-        JAVA_NAME = new DotName(null, "java", true, false);
-        JAVA_LANG_NAME = new DotName(JAVA_NAME, "lang", true, false);
-        JAVA_LANG_ANNOTATION_NAME = new DotName(JAVA_LANG_NAME, "annotation", true, false);
-        OBJECT_NAME = new DotName(JAVA_LANG_NAME, "Object", true, false);
-        ENUM_NAME = new DotName(JAVA_LANG_NAME, "Enum", true, false);
-        RECORD_NAME = new DotName(JAVA_LANG_NAME, "Record", true, false);
-        STRING_NAME = new DotName(JAVA_LANG_NAME, "String", true, false);
-        CLASS_NAME = new DotName(JAVA_LANG_NAME, "Class", true, false);
-        INHERITED_NAME = new DotName(JAVA_LANG_ANNOTATION_NAME, "Inherited", true, false);
-        REPEATABLE_NAME = new DotName(JAVA_LANG_ANNOTATION_NAME, "Repeatable", true, false);
-        RETENTION_NAME = new DotName(DotName.JAVA_LANG_ANNOTATION_NAME, "Retention", true, false);
+        JAVA_NAME = createComponentized(null, "java");
+        JAVA_LANG_NAME = createComponentized(JAVA_NAME, "lang");
+        JAVA_LANG_ANNOTATION_NAME = createComponentized(JAVA_LANG_NAME, "annotation");
+
+        OBJECT_NAME = createComponentized(JAVA_LANG_NAME, "Object");
+        CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Class");
+        ENUM_NAME = createComponentized(JAVA_LANG_NAME, "Enum");
+        RECORD_NAME = createComponentized(JAVA_LANG_NAME, "Record");
+        STRING_NAME = createComponentized(JAVA_LANG_NAME, "String");
+
+        BOOLEAN_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Boolean");
+        BYTE_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Byte");
+        SHORT_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Short");
+        INTEGER_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Integer");
+        LONG_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Long");
+        FLOAT_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Float");
+        DOUBLE_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Double");
+        CHARACTER_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Character");
+        VOID_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Void");
+
+        INHERITED_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Inherited");
+        REPEATABLE_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Repeatable");
+        RETENTION_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Retention");
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/JandexReflection.java
+++ b/core/src/main/java/org/jboss/jandex/JandexReflection.java
@@ -185,7 +185,9 @@ public class JandexReflection {
         public int hashCode() {
             // this `hashCode()` is not compatible with the JDK, but that doesn't really matter,
             // because it's not possible to implement a compatible `equals()` anyway
-            return Objects.hash(name, Arrays.hashCode(bounds));
+            int result = Objects.hashCode(name);
+            result = 31 * result + Arrays.hashCode(bounds);
+            return result;
         }
 
         @Override

--- a/core/src/main/java/org/jboss/jandex/TypeVariableReference.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariableReference.java
@@ -167,6 +167,8 @@ public final class TypeVariableReference extends Type {
     @Override
     int internHashCode() {
         // must produce predictable hash code (for reproducibility) consistent with `internEquals`
-        return Objects.hash(name, internalClassName);
+        int result = Objects.hashCode(name);
+        result = 31 * result + Objects.hashCode(internalClassName);
+        return result;
     }
 }

--- a/core/src/test/java/org/jboss/jandex/test/EquivalenceKeyTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/EquivalenceKeyTest.java
@@ -1,0 +1,58 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.EquivalenceKey;
+import org.jboss.jandex.PrimitiveType;
+import org.junit.jupiter.api.Test;
+
+public class EquivalenceKeyTest {
+    @Test
+    public void internedPrimitiveTypes() {
+        assertSame(EquivalenceKey.of(PrimitiveType.INT), EquivalenceKey.of(PrimitiveType.INT));
+        assertNotSame(EquivalenceKey.of(PrimitiveType.INT), EquivalenceKey.of(PrimitiveType.LONG));
+    }
+
+    @Test
+    public void internedClassTypes() {
+        // componentized names
+        assertSame(EquivalenceKey.of(ClassType.STRING_TYPE), EquivalenceKey.of(ClassType.STRING_TYPE));
+        assertSame(EquivalenceKey.of(ClassType.create(DotName.STRING_NAME)),
+                EquivalenceKey.of(ClassType.create(DotName.STRING_NAME)));
+
+        assertNotSame(EquivalenceKey.of(ClassType.STRING_TYPE), EquivalenceKey.of(ClassType.OBJECT_TYPE));
+        assertNotSame(EquivalenceKey.of(ClassType.create(DotName.STRING_NAME)),
+                EquivalenceKey.of(ClassType.create(DotName.OBJECT_NAME)));
+
+        // simple names
+        DotName stringName = DotName.createSimple(String.class);
+        DotName objectName = DotName.createSimple(Object.class);
+        ClassType stringType = ClassType.create(stringName);
+        ClassType objectType = ClassType.create(objectName);
+
+        assertSame(EquivalenceKey.of(stringType), EquivalenceKey.of(stringType));
+        assertSame(EquivalenceKey.of(ClassType.create(stringName)), EquivalenceKey.of(ClassType.create(stringName)));
+
+        assertNotSame(EquivalenceKey.of(stringType), EquivalenceKey.of(objectType));
+        assertNotSame(EquivalenceKey.of(ClassType.create(stringName)), EquivalenceKey.of(ClassType.create(objectName)));
+
+        // mixed names
+        assertSame(EquivalenceKey.of(stringType), EquivalenceKey.of(ClassType.STRING_TYPE));
+        assertSame(EquivalenceKey.of(ClassType.create(stringName)), EquivalenceKey.of(ClassType.create(DotName.STRING_NAME)));
+
+        assertNotSame(EquivalenceKey.of(stringType), EquivalenceKey.of(ClassType.OBJECT_TYPE));
+        assertNotSame(EquivalenceKey.of(ClassType.create(stringName)),
+                EquivalenceKey.of(ClassType.create(DotName.OBJECT_NAME)));
+    }
+
+    @Test
+    public void notInternedClassTypes() {
+        DotName name = DotName.createSimple(EquivalenceKeyTest.class);
+        ClassType type = ClassType.create(name);
+        assertNotSame(EquivalenceKey.of(type), EquivalenceKey.of(type));
+        assertNotSame(EquivalenceKey.of(ClassType.create(name)), EquivalenceKey.of(ClassType.create(name)));
+    }
+}


### PR DESCRIPTION
Primitive types and `java.*` class types are very commonly used and there is a limited number of them. Therefore, we can intern them safely (growth of the interning cache is naturally bounded) and improve allocation rate significantly.

Further, this commit removes all calls to `Objects.hash()`, because each call allocates an array. It is especially useless when called with just one element.

Co-authored-by: Guillaume Smet <guillaume.smet@gmail.com>