### PR TITLE
add Gizmo 2 integration

### DIFF
--- a/core/src/main/module/module-info.java
+++ b/core/src/main/module/module-info.java
@@ -1,3 +1,6 @@
+/**
+ * Java class file indexer and offline reflection library.
+ */
 module org.jboss.jandex {
     exports org.jboss.jandex;
 

--- a/gizmo2/pom.xml
+++ b/gizmo2/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-parent</artifactId>
+        <version>3.3.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jandex-gizmo2</artifactId>
+
+    <name>Jandex: Gizmo2 Integration</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.gizmo</groupId>
+            <artifactId>gizmo2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-module-info</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <module>
+                                <moduleInfoFile>src/main/module/module-info.java</moduleInfoFile>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gizmo2/src/main/java/org/jboss/jandex/gizmo2/Jandex2Gizmo.java
+++ b/gizmo2/src/main/java/org/jboss/jandex/gizmo2/Jandex2Gizmo.java
@@ -1,0 +1,651 @@
+package org.jboss.jandex.gizmo2;
+
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
+import static java.lang.constant.ConstantDescs.CD_Object;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.WildcardType;
+
+import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.TypeArgument;
+import io.quarkus.gizmo2.creator.AnnotatableCreator;
+import io.quarkus.gizmo2.creator.AnnotationCreator;
+import io.quarkus.gizmo2.creator.TypeParameterizedCreator;
+import io.quarkus.gizmo2.desc.ClassMethodDesc;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+
+/**
+ * Bridge methods from {@code org.jboss.jandex} types to the Gizmo 2 API.
+ */
+public class Jandex2Gizmo {
+    /**
+     * {@return the {@link ClassDesc} corresponding to the given Jandex {@link DotName}}
+     * See {@link Type#name()} for the description of the format this method recognizes.
+     *
+     * @param name the Jandex {@code DotName} (must not be {@code null})
+     */
+    public static ClassDesc classDescOf(DotName name) {
+        if (name.prefix() == null) {
+            String local = name.local();
+            return switch (local) {
+                case "void" -> ConstantDescs.CD_void;
+                case "boolean" -> ConstantDescs.CD_boolean;
+                case "byte" -> ConstantDescs.CD_byte;
+                case "short" -> ConstantDescs.CD_short;
+                case "int" -> ConstantDescs.CD_int;
+                case "long" -> ConstantDescs.CD_long;
+                case "float" -> ConstantDescs.CD_float;
+                case "double" -> ConstantDescs.CD_double;
+                case "char" -> ConstantDescs.CD_char;
+                default -> ofClassOrArray(local);
+            };
+        }
+        return ofClassOrArray(name.toString());
+    }
+
+    private static ClassDesc ofClassOrArray(String name) {
+        int dimensions = 0;
+        while (name.charAt(dimensions) == '[') {
+            dimensions++;
+        }
+        if (dimensions == 0) {
+            // `name` must be a binary name of a class
+            return ClassDesc.of(name);
+        }
+
+        ClassDesc elementType = name.charAt(dimensions) == 'L'
+                // class type, need to skip `L` at the beginning and `;` at the end
+                ? ClassDesc.of(name.substring(dimensions + 1, name.length() - 1))
+                // primitive type, the rest of `name` is just the primitive descriptor
+                : ClassDesc.ofDescriptor(name.substring(dimensions));
+        return elementType.arrayType(dimensions);
+    }
+
+    /**
+     * {@return the {@link ClassDesc} corresponding to the erasure of given Jandex {@link Type}}
+     *
+     * @param type the Jandex type (must not be {@code null})
+     */
+    public static ClassDesc classDescOf(Type type) {
+        return switch (type.kind()) {
+            case VOID -> ConstantDescs.CD_void;
+            case PRIMITIVE -> switch (type.asPrimitiveType().primitive()) {
+                case BOOLEAN -> ConstantDescs.CD_boolean;
+                case BYTE -> ConstantDescs.CD_byte;
+                case SHORT -> ConstantDescs.CD_short;
+                case INT -> ConstantDescs.CD_int;
+                case LONG -> ConstantDescs.CD_long;
+                case FLOAT -> ConstantDescs.CD_float;
+                case DOUBLE -> ConstantDescs.CD_double;
+                case CHAR -> ConstantDescs.CD_char;
+            };
+            case ARRAY -> {
+                ArrayType arrayType = type.asArrayType();
+                ClassDesc element = classDescOf(arrayType.elementType());
+                yield element.arrayType(arrayType.deepDimensions());
+            }
+            default -> classDescOf(type.name());
+        };
+    }
+
+    /**
+     * {@return the {@link ClassDesc} corresponding to the given Jandex {@link ClassInfo}}
+     *
+     * @param clazz the Jandex class (must not be {@code null})
+     */
+    public static ClassDesc classDescOf(ClassInfo clazz) {
+        return classDescOf(clazz.name());
+    }
+
+    /**
+     * {@return the {@link FieldDesc} corresponding to the given Jandex {@link FieldInfo}}
+     *
+     * @param field the Jandex field (must not be {@code null})
+     */
+    public static FieldDesc fieldDescOf(FieldInfo field) {
+        return FieldDesc.of(classDescOf(field.declaringClass()), field.name(), classDescOf(field.type()));
+    }
+
+    /**
+     * {@return the {@link MethodDesc} corresponding to the given Jandex {@link MethodInfo}}
+     *
+     * @param method the Jandex method (must not be {@code null})
+     * @throws IllegalArgumentException if the {@code method} is a static initializer or constructor
+     */
+    public static MethodDesc methodDescOf(MethodInfo method) {
+        if (method.isConstructor()) {
+            throw new IllegalArgumentException("Cannot create MethodDesc for constructor: " + method);
+        }
+        if (method.isStaticInitializer()) {
+            throw new IllegalArgumentException("Cannot create MethodDesc for static initializer: " + method);
+        }
+
+        ClassDesc owner = classDescOf(method.declaringClass());
+        ClassDesc returnType = classDescOf(method.returnType());
+        ClassDesc[] paramTypes = new ClassDesc[method.parametersCount()];
+        for (int i = 0; i < method.parametersCount(); i++) {
+            paramTypes[i] = classDescOf(method.parameterType(i));
+        }
+        MethodTypeDesc methodTypeDesc = MethodTypeDesc.of(returnType, paramTypes);
+        return method.declaringClass().isInterface()
+                ? InterfaceMethodDesc.of(owner, method.name(), methodTypeDesc)
+                : ClassMethodDesc.of(owner, method.name(), methodTypeDesc);
+    }
+
+    /**
+     * {@return the {@link ConstructorDesc} corresponding to the given Jandex {@link MethodInfo}}
+     *
+     * @param ctor the Jandex constructor (must not be {@code null})
+     * @throws IllegalArgumentException if the {@code ctor} is not a constructor
+     */
+    public static ConstructorDesc constructorDescOf(MethodInfo ctor) {
+        if (ctor.isStaticInitializer()) {
+            throw new IllegalArgumentException("Cannot create ConstructorDesc for static initializer: " + ctor);
+        }
+        if (!ctor.isConstructor()) {
+            throw new IllegalArgumentException("Cannot create ConstructorDesc for regular method: " + ctor);
+        }
+
+        List<ClassDesc> paramTypes = new ArrayList<>(ctor.parametersCount());
+        for (int i = 0; i < ctor.parametersCount(); i++) {
+            paramTypes.add(classDescOf(ctor.parameterType(i)));
+        }
+        return ConstructorDesc.of(classDescOf(ctor.declaringClass()), paramTypes);
+    }
+
+    /**
+     * {@return a {@link GenericType } corresponding to the given Jandex {@link DotName}}
+     *
+     * @param name the Jandex {@code DotName} (must not be {@code null})
+     */
+    public static GenericType genericTypeOf(DotName name) {
+        return GenericType.of(classDescOf(name));
+    }
+
+    /**
+     * {@return a {@link GenericType} corresponding to the given Jandex {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     */
+    public static GenericType genericTypeOf(Type type) {
+        return genericTypeOf(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType} corresponding to the given Jandex {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     */
+    public static GenericType genericTypeOf(Type type, IndexView index) {
+        return switch (type.kind()) {
+            case VOID, PRIMITIVE -> genericTypeOfPrimitive(type, index);
+            default -> genericTypeOfReference(type, index);
+        };
+    }
+
+    /**
+     * {@return a {@link GenericType.OfPrimitive} corresponding to the given Jandex primitive {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a primitive type or {@code void}
+     */
+    public static GenericType.OfPrimitive genericTypeOfPrimitive(Type type) {
+        return genericTypeOfPrimitive(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType.OfPrimitive} corresponding to the given Jandex primitive {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a primitive type or {@code void}
+     */
+    public static GenericType.OfPrimitive genericTypeOfPrimitive(Type type, IndexView index) {
+        GenericType.OfPrimitive result = switch (type.kind()) {
+            case VOID -> GenericType.ofPrimitive(void.class);
+            case PRIMITIVE -> switch (type.asPrimitiveType().primitive()) {
+                case BOOLEAN -> GenericType.ofPrimitive(boolean.class);
+                case BYTE -> GenericType.ofPrimitive(byte.class);
+                case SHORT -> GenericType.ofPrimitive(short.class);
+                case INT -> GenericType.ofPrimitive(int.class);
+                case LONG -> GenericType.ofPrimitive(long.class);
+                case FLOAT -> GenericType.ofPrimitive(float.class);
+                case DOUBLE -> GenericType.ofPrimitive(double.class);
+                case CHAR -> GenericType.ofPrimitive(char.class);
+            };
+            default -> throw new IllegalArgumentException("Not a primitive type: " + type);
+        };
+        return index == null ? result : result.withAnnotations(copyAnnotations(type, index));
+    }
+
+    /**
+     * {@return a {@link GenericType.OfReference} corresponding to the given Jandex reference {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a reference type
+     */
+    public static GenericType.OfReference genericTypeOfReference(Type type) {
+        return genericTypeOfReference(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType.OfReference} corresponding to the given Jandex reference {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a reference type
+     */
+    public static GenericType.OfReference genericTypeOfReference(Type type, IndexView index) {
+        return switch (type.kind()) {
+            case VOID, PRIMITIVE -> throw new IllegalArgumentException("Not a reference type: " + type);
+            case ARRAY -> genericTypeOfArray(type, index);
+            default -> genericTypeOfThrows(type, index);
+        };
+    }
+
+    /**
+     * {@return a {@link GenericType.OfArray} corresponding to the given Jandex array {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not an array type
+     */
+    public static GenericType.OfArray genericTypeOfArray(Type type) {
+        return genericTypeOfArray(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType.OfArray} corresponding to the given Jandex array {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not an array type
+     */
+    public static GenericType.OfArray genericTypeOfArray(Type type, IndexView index) {
+        if (type.kind() != Type.Kind.ARRAY) {
+            throw new IllegalArgumentException("Not an array type: " + type);
+        }
+
+        GenericType constituent = genericTypeOf(type.asArrayType().constituent(), index);
+        GenericType.OfArray result = constituent.arrayType();
+        for (int i = 1; i < type.asArrayType().dimensions(); i++) {
+            result = result.arrayType();
+        }
+        assert result != null;
+        return index == null ? result : result.withAnnotations(copyAnnotations(type, index));
+    }
+
+    /**
+     * {@return a {@link GenericType.OfThrows} corresponding to the given Jandex throwable {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a throwable type
+     */
+    public static GenericType.OfThrows genericTypeOfThrows(Type type) {
+        return genericTypeOfThrows(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType.OfThrows} corresponding to the given Jandex throwable {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a throwable type
+     */
+    public static GenericType.OfThrows genericTypeOfThrows(Type type, IndexView index) {
+        return switch (type.kind()) {
+            case VOID, PRIMITIVE, ARRAY -> throw new IllegalArgumentException("Not a throwable type: " + type);
+            case CLASS, PARAMETERIZED_TYPE -> genericTypeOfClass(type, index);
+            case TYPE_VARIABLE, TYPE_VARIABLE_REFERENCE, UNRESOLVED_TYPE_VARIABLE -> genericTypeOfTypeVariable(type, index);
+            case WILDCARD_TYPE -> throw new IllegalArgumentException("Wildcard types may only be type arguments");
+        };
+    }
+
+    /**
+     * {@return a {@link GenericType.OfClass} corresponding to the given Jandex class or parameterized {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a class or parameterized type
+     */
+    public static GenericType.OfClass genericTypeOfClass(Type type) {
+        return genericTypeOfClass(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType.OfClass} corresponding to the given Jandex class or parameterized {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a class or parameterized type
+     */
+    public static GenericType.OfClass genericTypeOfClass(Type type, IndexView index) {
+        GenericType.OfClass result = switch (type.kind()) {
+            case CLASS -> GenericType.ofClass(classDescOf(type.name()));
+            case PARAMETERIZED_TYPE -> {
+                List<Type> typeArgs = type.asParameterizedType().arguments();
+                List<TypeArgument> translatedTypeArgs = new ArrayList<>(typeArgs.size());
+                for (Type typeArg : typeArgs) {
+                    translatedTypeArgs.add(typeArgumentOf(typeArg, index));
+                }
+                Type owner = type.asParameterizedType().owner();
+                if (owner != null) {
+                    GenericType.OfClass translatedOwner = genericTypeOfClass(owner, index);
+                    yield GenericType.ofInnerClass(translatedOwner, type.name().local()).withArguments(translatedTypeArgs);
+                } else {
+                    yield GenericType.ofClass(classDescOf(type.name()), translatedTypeArgs);
+                }
+            }
+            default -> throw new IllegalArgumentException("Not a class/parameterized type: " + type);
+        };
+        return index == null ? result : result.withAnnotations(copyAnnotations(type, index));
+    }
+
+    /**
+     * {@return a {@link GenericType.OfTypeVariable} corresponding to the given Jandex {@link Type} variable}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a type variable
+     */
+    public static GenericType.OfTypeVariable genericTypeOfTypeVariable(Type type) {
+        return genericTypeOfTypeVariable(type, null);
+    }
+
+    /**
+     * {@return a {@link GenericType.OfTypeVariable} corresponding to the given Jandex {@link Type} variable}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} is not a type variable
+     */
+    public static GenericType.OfTypeVariable genericTypeOfTypeVariable(Type type, IndexView index) {
+        GenericType.OfTypeVariable result = switch (type.kind()) {
+            case TYPE_VARIABLE ->
+                GenericType.ofTypeVariable(type.asTypeVariable().identifier(), classDescOf(type.name()));
+            case TYPE_VARIABLE_REFERENCE ->
+                GenericType.ofTypeVariable(type.asTypeVariableReference().identifier(), classDescOf(type.name()));
+            case UNRESOLVED_TYPE_VARIABLE ->
+                GenericType.ofTypeVariable(type.asUnresolvedTypeVariable().identifier(), CD_Object);
+            default -> throw new IllegalArgumentException("Not a type variable: " + type);
+        };
+        return index == null ? result : result.withAnnotations(copyAnnotations(type, index));
+    }
+
+    /**
+     * {@return a {@link TypeArgument} corresponding to the given Jandex {@link Type}}
+     * The result does <em>not</em> include type annotations.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} cannot be a type argument
+     */
+    public static TypeArgument typeArgumentOf(Type type) {
+        return typeArgumentOf(type, null);
+    }
+
+    /**
+     * {@return a {@link TypeArgument} corresponding to the given Jandex {@link Type}}
+     * The result includes type annotations if the {@code index} is not {@code null}.
+     *
+     * @param type the Jandex {@code Type} (must not be {@code null})
+     * @param index the Jandex index that contains classes of type annotations (may be {@code null})
+     * @throws IllegalArgumentException if the given {@code type} cannot be a type argument
+     */
+    public static TypeArgument typeArgumentOf(Type type, IndexView index) {
+        return switch (type.kind()) {
+            case VOID, PRIMITIVE -> throw new IllegalArgumentException("Primitive types cannot be type arguments");
+            case CLASS, PARAMETERIZED_TYPE, ARRAY, TYPE_VARIABLE, TYPE_VARIABLE_REFERENCE, UNRESOLVED_TYPE_VARIABLE ->
+                TypeArgument.ofExact(genericTypeOfReference(type, index));
+            case WILDCARD_TYPE -> {
+                TypeArgument.OfWildcard result;
+                WildcardType wildcard = type.asWildcardType();
+                if (wildcard.superBound() != null) {
+                    result = TypeArgument.ofSuper(genericTypeOfReference(wildcard.superBound(), index));
+                } else if (wildcard.extendsBound() != null && (!DotName.OBJECT_NAME.equals(wildcard.extendsBound().name())
+                        || !wildcard.extendsBound().annotations().isEmpty())) {
+                    // the `extends` bound is either not `Object`, or it has type annotations and must be explicit
+                    result = TypeArgument.ofExtends(genericTypeOfReference(wildcard.extendsBound(), index));
+                } else {
+                    result = TypeArgument.ofUnbounded();
+                }
+                yield index == null ? result : result.withAnnotations(copyAnnotations(type, index));
+            }
+        };
+    }
+
+    /**
+     * Copies type parameters from given {@code clazz} to the given {@code creator}, preserving order.
+     *
+     * @param clazz the Jandex {@link ClassInfo} (must not be {@code null})
+     * @param creator the Gizmo {@link TypeParameterizedCreator} (must not be {@code null})
+     */
+    public static void copyTypeParameters(ClassInfo clazz, TypeParameterizedCreator creator) {
+        copyTypeParameters(clazz.typeParameters(), creator);
+    }
+
+    /**
+     * Copies type parameters from given {@code method} to the given {@code creator}, preserving order.
+     *
+     * @param method the Jandex {@link MethodInfo} (must not be {@code null})
+     * @param creator the Gizmo {@link TypeParameterizedCreator} (must not be {@code null})
+     */
+    public static void copyTypeParameters(MethodInfo method, TypeParameterizedCreator creator) {
+        copyTypeParameters(method.typeParameters(), creator);
+    }
+
+    private static void copyTypeParameters(List<TypeVariable> typeParameters, TypeParameterizedCreator creator) {
+        for (TypeVariable typeParameter : typeParameters) {
+            addTypeParameter(typeParameter, creator);
+        }
+    }
+
+    /**
+     * Adds the given {@code typeParameter} to the given {@code creator}.
+     *
+     * @param typeParameter the Jandex {@link TypeVariable} (must not be {@code null})
+     * @param creator the Gizmo {@link TypeParameterizedCreator} (must not be {@code null})
+     */
+    public static void addTypeParameter(TypeVariable typeParameter, TypeParameterizedCreator creator) {
+        List<Type> bounds = typeParameter.bounds();
+        if (bounds.isEmpty()) {
+            creator.typeParameter(typeParameter.identifier());
+        } else if (bounds.get(0) instanceof TypeVariable) {
+            creator.typeParameter(typeParameter.identifier(), tpc -> {
+                tpc.setFirstBound(genericTypeOfTypeVariable(bounds.get(0)));
+            });
+        } else {
+            creator.typeParameter(typeParameter.identifier(), tpc -> {
+                int firstInterfaceBound = 0;
+                if (!typeParameter.hasImplicitObjectBound()) {
+                    tpc.setFirstBound(genericTypeOfClass(bounds.get(0)));
+                    firstInterfaceBound = 1;
+                }
+                if (typeParameter.bounds().size() > firstInterfaceBound) {
+                    List<GenericType.OfClass> other = new ArrayList<>(bounds.size() - firstInterfaceBound);
+                    for (int i = firstInterfaceBound; i < bounds.size(); i++) {
+                        other.add(genericTypeOfClass(bounds.get(i)));
+                    }
+                    tpc.setOtherBounds(other);
+                }
+            });
+        }
+    }
+
+    /**
+     * {@return an {@link AnnotatableCreator} consumer that copies all annotations from given {@code AnnotationTarget}}
+     *
+     * @param annotationTarget the {@link AnnotationTarget} from which to copy the annotations (must not be {@code null})
+     * @param index the Jandex index that contains annotation classes (must not be {@code null})
+     */
+    public static Consumer<AnnotatableCreator> copyAnnotations(AnnotationTarget annotationTarget, IndexView index) {
+        return creator -> {
+            for (AnnotationInstance annotation : annotationTarget.annotations()) {
+                addAnnotation(creator, annotation, index);
+            }
+        };
+    }
+
+    /**
+     * {@return an {@link AnnotatableCreator} consumer that copies all annotations from given {@code Type}}
+     *
+     * @param type the {@link Type} from which to copy the annotations (must not be {@code null})
+     * @param index the Jandex index that contains annotation classes (must not be {@code null})
+     */
+    public static Consumer<AnnotatableCreator> copyAnnotations(Type type, IndexView index) {
+        return creator -> {
+            for (AnnotationInstance annotation : type.annotations()) {
+                addAnnotation(creator, annotation, index);
+            }
+        };
+    }
+
+    /**
+     * Adds the given {@code annotation} to the given {@code annotatableCreator}.
+     *
+     * @param annotatableCreator the {@link AnnotatableCreator} to which to add the annotation (must not be {@code null})
+     * @param annotation the {@link AnnotationInstance} to add (must not be {@code null})
+     * @param index the Jandex index that contains annotation classes (must not be {@code null})
+     */
+    public static void addAnnotation(AnnotatableCreator annotatableCreator, AnnotationInstance annotation, IndexView index) {
+        RetentionPolicy retention = annotation.runtimeVisible() ? RetentionPolicy.RUNTIME : RetentionPolicy.CLASS;
+        annotatableCreator.addAnnotation(classDescOf(annotation.name()), retention, creatorFor(annotation, index));
+    }
+
+    private static Consumer<AnnotationCreator<Annotation>> creatorFor(AnnotationInstance annotation, IndexView index) {
+        return creator -> {
+            for (AnnotationValue member : annotation.values()) {
+                switch (member.kind()) {
+                    case BOOLEAN -> creator.add(member.name(), member.asBoolean());
+                    case BYTE -> creator.add(member.name(), member.asByte());
+                    case SHORT -> creator.add(member.name(), member.asShort());
+                    case INTEGER -> creator.add(member.name(), member.asInt());
+                    case LONG -> creator.add(member.name(), member.asLong());
+                    case FLOAT -> creator.add(member.name(), member.asFloat());
+                    case DOUBLE -> creator.add(member.name(), member.asDouble());
+                    case CHARACTER -> creator.add(member.name(), member.asChar());
+                    case STRING -> creator.add(member.name(), member.asString());
+                    case CLASS -> creator.add(member.name(), classDescOf(member.asClass()));
+                    case ENUM -> creator.add(member.name(), classDescOf(member.asEnumType()), member.asEnum());
+                    case NESTED -> creator.add(member.name(), classDescOf(member.asNested().name()),
+                            creatorFor(member.asNested(), index));
+                    case ARRAY -> {
+                        switch (member.componentKind()) {
+                            case BOOLEAN -> creator.addArray(member.name(), member.asBooleanArray());
+                            case BYTE -> creator.addArray(member.name(), member.asByteArray());
+                            case SHORT -> creator.addArray(member.name(), member.asShortArray());
+                            case INTEGER -> creator.addArray(member.name(), member.asIntArray());
+                            case LONG -> creator.addArray(member.name(), member.asLongArray());
+                            case FLOAT -> creator.addArray(member.name(), member.asFloatArray());
+                            case DOUBLE -> creator.addArray(member.name(), member.asDoubleArray());
+                            case CHARACTER -> creator.addArray(member.name(), member.asCharArray());
+                            case STRING -> creator.addArray(member.name(), member.asStringArray());
+                            case CLASS -> {
+                                Type[] in = member.asClassArray();
+                                ClassDesc[] out = new ClassDesc[in.length];
+                                for (int i = 0; i < in.length; i++) {
+                                    out[i] = classDescOf(in[i]);
+                                }
+                                creator.addArray(member.name(), out);
+                            }
+                            case ENUM -> {
+                                DotName[] array = member.asEnumTypeArray();
+                                assert array.length > 0;
+                                ClassDesc enumType = classDescOf(array[0]);
+                                creator.addArray(member.name(), enumType, member.asEnumArray());
+                            }
+                            case NESTED -> {
+                                AnnotationInstance[] array = member.asNestedArray();
+                                assert array.length > 0;
+                                ClassDesc nestedType = classDescOf(array[0].name());
+                                List<Consumer<AnnotationCreator<Annotation>>> creators = new ArrayList<>(array.length);
+                                for (AnnotationInstance nested : array) {
+                                    creators.add(creatorFor(nested, index));
+                                }
+                                creator.addArray(member.name(), nestedType, creators);
+                            }
+                            case UNKNOWN -> {
+                                // empty array -- the only place where we need the `index`
+                                ClassInfo annotationClass = index.getClassByName(annotation.name());
+                                if (annotationClass == null) {
+                                    throw new IllegalArgumentException("Given index does not contain " + annotation.name());
+                                }
+                                MethodInfo memberMethod = annotationClass.method(member.name());
+                                assert memberMethod.returnType().kind() == Type.Kind.ARRAY;
+                                Type type = memberMethod.returnType().asArrayType().elementType();
+                                if (PrimitiveType.BOOLEAN.equals(type)) {
+                                    creator.addArray(member.name(), new boolean[0]);
+                                } else if (PrimitiveType.BYTE.equals(type)) {
+                                    creator.addArray(member.name(), new byte[0]);
+                                } else if (PrimitiveType.SHORT.equals(type)) {
+                                    creator.addArray(member.name(), new short[0]);
+                                } else if (PrimitiveType.INT.equals(type)) {
+                                    creator.addArray(member.name(), new int[0]);
+                                } else if (PrimitiveType.LONG.equals(type)) {
+                                    creator.addArray(member.name(), new long[0]);
+                                } else if (PrimitiveType.FLOAT.equals(type)) {
+                                    creator.addArray(member.name(), new float[0]);
+                                } else if (PrimitiveType.DOUBLE.equals(type)) {
+                                    creator.addArray(member.name(), new double[0]);
+                                } else if (PrimitiveType.CHAR.equals(type)) {
+                                    creator.addArray(member.name(), new char[0]);
+                                } else if (DotName.STRING_NAME.equals(type.name())) {
+                                    creator.addArray(member.name(), new String[0]);
+                                } else if (DotName.CLASS_NAME.equals(type.name())) {
+                                    creator.addArray(member.name(), new Class[0]);
+                                } else {
+                                    assert type.kind() == Type.Kind.CLASS;
+                                    ClassInfo clazz = index.getClassByName(type.name());
+                                    if (clazz.isEnum()) {
+                                        creator.addArray(member.name(), classDescOf(clazz), new String[0]);
+                                    } else if (clazz.isAnnotation()) {
+                                        creator.addArray(member.name(), classDescOf(clazz), List.of());
+                                    } else {
+                                        throw new IllegalArgumentException("Unknown type of empty array: "
+                                                + memberMethod + " at " + memberMethod.declaringClass());
+                                    }
+                                }
+                            }
+                            default -> throw impossibleSwitchCase(member.kind());
+                        }
+                    }
+                    default -> throw impossibleSwitchCase(member.kind());
+                }
+            }
+        };
+    }
+}

--- a/gizmo2/src/main/module/module-info.java
+++ b/gizmo2/src/main/module/module-info.java
@@ -1,0 +1,8 @@
+/**
+ * Jandex integration with Gizmo 2.
+ */
+module org.jboss.jandex.gizmo2 {
+    requires io.quarkus.gizmo2;
+
+    exports org.jboss.jandex.gizmo2;
+}

--- a/gizmo2/src/test/java/org/jboss/jandex/gizmo2/Jandex2GizmoTest.java
+++ b/gizmo2/src/test/java/org/jboss/jandex/gizmo2/Jandex2GizmoTest.java
@@ -1,0 +1,366 @@
+package org.jboss.jandex.gizmo2;
+
+import static java.lang.constant.ConstantDescs.CD_Boolean;
+import static java.lang.constant.ConstantDescs.CD_Byte;
+import static java.lang.constant.ConstantDescs.CD_Character;
+import static java.lang.constant.ConstantDescs.CD_Double;
+import static java.lang.constant.ConstantDescs.CD_Float;
+import static java.lang.constant.ConstantDescs.CD_Integer;
+import static java.lang.constant.ConstantDescs.CD_List;
+import static java.lang.constant.ConstantDescs.CD_Long;
+import static java.lang.constant.ConstantDescs.CD_Map;
+import static java.lang.constant.ConstantDescs.CD_Number;
+import static java.lang.constant.ConstantDescs.CD_Object;
+import static java.lang.constant.ConstantDescs.CD_Short;
+import static java.lang.constant.ConstantDescs.CD_String;
+import static java.lang.constant.ConstantDescs.CD_boolean;
+import static java.lang.constant.ConstantDescs.CD_byte;
+import static java.lang.constant.ConstantDescs.CD_char;
+import static java.lang.constant.ConstantDescs.CD_double;
+import static java.lang.constant.ConstantDescs.CD_float;
+import static java.lang.constant.ConstantDescs.CD_int;
+import static java.lang.constant.ConstantDescs.CD_long;
+import static java.lang.constant.ConstantDescs.CD_short;
+import static java.lang.constant.ConstantDescs.CD_void;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.constructorDescOf;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.fieldDescOf;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.genericTypeOf;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.methodDescOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.VoidType;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.gizmo2.Reflection2Gizmo;
+import io.quarkus.gizmo2.desc.ClassMethodDesc;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
+
+public class Jandex2GizmoTest {
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyAnn {
+        int value();
+    }
+
+    @SuppressWarnings({ "InnerClassMayBeStatic", "unused" })
+    static class A<T> {
+        class B {
+        }
+
+        class C<U> {
+        }
+
+        static class D {
+            static class E {
+            }
+
+            class F<U> {
+            }
+        }
+
+        static class G<U> {
+            static class H<V> {
+            }
+
+            class I {
+            }
+        }
+    }
+
+    static class FooBar {
+        int f1;
+        A<String>.B f2;
+        Integer[] f3;
+
+        FooBar(int p1, A<String>.B p2, Integer[] p3) {
+        }
+
+        void m1(String p1) {
+        }
+
+        A<Integer> m2(A<String>.B p1, List<String> p2) {
+            return null;
+        }
+
+        <T extends Number> T m3(List<?> p1, Map<? extends T, ? super String> p2) {
+            return null;
+        }
+
+        static <T> void foobar(
+                @MyAnn(1) int p1,
+                @MyAnn(2) String p2,
+                @MyAnn(3) List<@MyAnn(4) String> p3,
+                @MyAnn(5) String[] @MyAnn(6) [] p4,
+                @MyAnn(7) List<@MyAnn(8) ? extends @MyAnn(9) String> p5,
+                @MyAnn(10) Map<@MyAnn(11) ?, @MyAnn(12) ? super @MyAnn(13) String> p6,
+                @MyAnn(14) A<@MyAnn(15) String>.@MyAnn(16) B p7,
+                @MyAnn(17) A<@MyAnn(18) String>.@MyAnn(19) C<@MyAnn(20) String> p8,
+                A.@MyAnn(21) D p9,
+                A.D.@MyAnn(22) E p10,
+                A.@MyAnn(23) D.@MyAnn(24) F<@MyAnn(25) String> p11,
+                A.@MyAnn(26) G<@MyAnn(27) String> p12,
+                A.G.H<@MyAnn(28) String> p13,
+                A.G<@MyAnn(29) String>.@MyAnn(30) I p14,
+                @MyAnn(31) T p15,
+                @MyAnn(32) List<@MyAnn(33) ? super @MyAnn(34) T> p16) {
+        }
+    }
+
+    static final ClassDesc A_DESC = Reflection2Gizmo.classDescOf(A.class);
+
+    static final ClassDesc A_B_DESC = A_DESC.nested("B");
+
+    static final ClassDesc FOO_BAR_DESC = Reflection2Gizmo.classDescOf(FooBar.class);
+
+    @Test
+    public void classDescFromDotName() {
+        assertEquals(CD_void, classDescOf(DotName.createSimple("void")));
+
+        assertEquals(CD_boolean, classDescOf(DotName.createSimple("boolean")));
+        assertEquals(CD_byte, classDescOf(DotName.createSimple("byte")));
+        assertEquals(CD_short, classDescOf(DotName.createSimple("short")));
+        assertEquals(CD_int, classDescOf(DotName.createSimple("int")));
+        assertEquals(CD_long, classDescOf(DotName.createSimple("long")));
+        assertEquals(CD_float, classDescOf(DotName.createSimple("float")));
+        assertEquals(CD_double, classDescOf(DotName.createSimple("double")));
+        assertEquals(CD_char, classDescOf(DotName.createSimple("char")));
+
+        assertEquals(CD_Boolean, classDescOf(DotName.BOOLEAN_CLASS_NAME));
+        assertEquals(CD_Byte, classDescOf(DotName.BYTE_CLASS_NAME));
+        assertEquals(CD_Short, classDescOf(DotName.SHORT_CLASS_NAME));
+        assertEquals(CD_Integer, classDescOf(DotName.INTEGER_CLASS_NAME));
+        assertEquals(CD_Long, classDescOf(DotName.LONG_CLASS_NAME));
+        assertEquals(CD_Float, classDescOf(DotName.FLOAT_CLASS_NAME));
+        assertEquals(CD_Double, classDescOf(DotName.DOUBLE_CLASS_NAME));
+        assertEquals(CD_Character, classDescOf(DotName.CHARACTER_CLASS_NAME));
+
+        assertEquals(CD_String, classDescOf(DotName.STRING_NAME));
+        assertEquals(CD_String, classDescOf(DotName.createSimple("java.lang.String")));
+        assertEquals(CD_Object, classDescOf(DotName.OBJECT_NAME));
+        assertEquals(CD_Object, classDescOf(DotName.createSimple("java.lang.Object")));
+
+        // see `Type.name()` for how array types are represented
+        assertEquals(CD_boolean.arrayType(), classDescOf(DotName.createSimple("[Z")));
+        assertEquals(CD_byte.arrayType().arrayType(), classDescOf(DotName.createSimple("[[B")));
+        assertEquals(CD_short.arrayType(3), classDescOf(DotName.createSimple("[[[S")));
+        assertEquals(CD_int.arrayType(4), classDescOf(DotName.createSimple("[[[[I")));
+        assertEquals(CD_long.arrayType(1), classDescOf(DotName.createSimple("[J")));
+        assertEquals(CD_float.arrayType(2), classDescOf(DotName.createSimple("[[F")));
+        assertEquals(CD_double.arrayType(3), classDescOf(DotName.createSimple("[[[D")));
+        assertEquals(CD_char.arrayType(4), classDescOf(DotName.createSimple("[[[[C")));
+
+        assertEquals(CD_String.arrayType(), classDescOf(DotName.createSimple("[Ljava.lang.String;")));
+        assertEquals(CD_Object.arrayType(2), classDescOf(DotName.createSimple("[[Ljava.lang.Object;")));
+    }
+
+    @Test
+    public void classDescFromType() {
+        assertEquals(CD_void, classDescOf(VoidType.VOID));
+
+        assertEquals(CD_boolean, classDescOf(PrimitiveType.BOOLEAN));
+        assertEquals(CD_byte, classDescOf(PrimitiveType.BYTE));
+        assertEquals(CD_short, classDescOf(PrimitiveType.SHORT));
+        assertEquals(CD_int, classDescOf(PrimitiveType.INT));
+        assertEquals(CD_long, classDescOf(PrimitiveType.LONG));
+        assertEquals(CD_float, classDescOf(PrimitiveType.FLOAT));
+        assertEquals(CD_double, classDescOf(PrimitiveType.DOUBLE));
+        assertEquals(CD_char, classDescOf(PrimitiveType.CHAR));
+
+        assertEquals(CD_Boolean, classDescOf(ClassType.BOOLEAN_CLASS));
+        assertEquals(CD_Byte, classDescOf(ClassType.BYTE_CLASS));
+        assertEquals(CD_Short, classDescOf(ClassType.SHORT_CLASS));
+        assertEquals(CD_Integer, classDescOf(ClassType.INTEGER_CLASS));
+        assertEquals(CD_Long, classDescOf(ClassType.LONG_CLASS));
+        assertEquals(CD_Float, classDescOf(ClassType.FLOAT_CLASS));
+        assertEquals(CD_Double, classDescOf(ClassType.DOUBLE_CLASS));
+        assertEquals(CD_Character, classDescOf(ClassType.CHARACTER_CLASS));
+
+        assertEquals(CD_String, classDescOf(ClassType.STRING_TYPE));
+        assertEquals(CD_Object, classDescOf(ClassType.OBJECT_TYPE));
+
+        assertEquals(CD_boolean.arrayType(), classDescOf(ArrayType.create(PrimitiveType.BOOLEAN, 1)));
+        assertEquals(CD_byte.arrayType().arrayType(), classDescOf(ArrayType.create(PrimitiveType.BYTE, 2)));
+        assertEquals(CD_short.arrayType(3), classDescOf(ArrayType.create(PrimitiveType.SHORT, 3)));
+        assertEquals(CD_int.arrayType(4), classDescOf(ArrayType.create(PrimitiveType.INT, 4)));
+        assertEquals(CD_long.arrayType(1), classDescOf(ArrayType.create(PrimitiveType.LONG, 1)));
+        assertEquals(CD_float.arrayType(2), classDescOf(ArrayType.create(PrimitiveType.FLOAT, 2)));
+        assertEquals(CD_double.arrayType(3), classDescOf(ArrayType.create(PrimitiveType.DOUBLE, 3)));
+        assertEquals(CD_char.arrayType(4), classDescOf(ArrayType.create(PrimitiveType.CHAR, 4)));
+
+        assertEquals(CD_String.arrayType(), classDescOf(ArrayType.create(ClassType.STRING_TYPE, 1)));
+        assertEquals(CD_Object.arrayType(2), classDescOf(ArrayType.create(ClassType.OBJECT_TYPE, 2)));
+
+        assertEquals(CD_List, classDescOf(ParameterizedType.builder(List.class).addArgument(String.class).build()));
+        assertEquals(CD_List.arrayType(), classDescOf(ArrayType.create(
+                ParameterizedType.builder(List.class).addArgument(String.class).build(), 1)));
+
+        assertEquals(CD_String, classDescOf(TypeVariable.builder("T").addBound(String.class).build()));
+        assertEquals(CD_Object, classDescOf(TypeVariable.create("T")));
+    }
+
+    @Test
+    public void classDescFromClass() throws IOException {
+        ClassInfo clazz = Index.singleClass(FooBar.class);
+        assertNotNull(clazz);
+        assertEquals(FOO_BAR_DESC, classDescOf(clazz));
+    }
+
+    @Test
+    public void fieldDescFromField() throws IOException {
+        ClassInfo clazz = Index.singleClass(FooBar.class);
+        assertNotNull(clazz);
+        FieldInfo f1 = clazz.field("f1");
+        assertNotNull(f1);
+        assertEquals(FieldDesc.of(FOO_BAR_DESC, "f1", CD_int), fieldDescOf(f1));
+        FieldInfo f2 = clazz.field("f2");
+        assertNotNull(f2);
+        assertEquals(FieldDesc.of(FOO_BAR_DESC, "f2", A_B_DESC), fieldDescOf(f2));
+        FieldInfo f3 = clazz.field("f3");
+        assertNotNull(f3);
+        assertEquals(FieldDesc.of(FOO_BAR_DESC, "f3", CD_Integer.arrayType()), fieldDescOf(f3));
+    }
+
+    @Test
+    public void methodDescFromMethod() throws IOException {
+        ClassInfo clazz = Index.singleClass(FooBar.class);
+        assertNotNull(clazz);
+        MethodInfo m1 = clazz.firstMethod("m1");
+        assertNotNull(m1);
+        assertEquals(ClassMethodDesc.of(FOO_BAR_DESC, "m1", MethodTypeDesc.of(CD_void, CD_String)), methodDescOf(m1));
+        MethodInfo m2 = clazz.firstMethod("m2");
+        assertNotNull(m2);
+        assertEquals(ClassMethodDesc.of(FOO_BAR_DESC, "m2", MethodTypeDesc.of(A_DESC, A_B_DESC, CD_List)), methodDescOf(m2));
+        MethodInfo m3 = clazz.firstMethod("m3");
+        assertNotNull(m3);
+        assertEquals(ClassMethodDesc.of(FOO_BAR_DESC, "m3", MethodTypeDesc.of(CD_Number, CD_List, CD_Map)), methodDescOf(m3));
+    }
+
+    @Test
+    public void constructorDescFromConstructor() throws IOException {
+        ClassInfo clazz = Index.singleClass(FooBar.class);
+        assertNotNull(clazz);
+        MethodInfo c = clazz.constructors().get(0); // there's just one
+        assertNotNull(c);
+        assertEquals(ConstructorDesc.of(FOO_BAR_DESC, CD_int, A_B_DESC, CD_Integer.arrayType()), constructorDescOf(c));
+    }
+
+    @Test
+    public void genericTypeFromType() throws IOException {
+        ClassInfo clazz = Index.singleClass(FooBar.class);
+        assertNotNull(clazz);
+        MethodInfo m = clazz.firstMethod("foobar");
+        assertNotNull(m);
+        assertEquals("int",
+                genericTypeOf(m.parameterType(0)).toString());
+        assertEquals("java.lang.String",
+                genericTypeOf(m.parameterType(1)).toString());
+        assertEquals("java.util.List<java.lang.String>",
+                genericTypeOf(m.parameterType(2)).toString());
+        assertEquals("java.lang.String[][]",
+                genericTypeOf(m.parameterType(3)).toString());
+        assertEquals("java.util.List<? extends java.lang.String>",
+                genericTypeOf(m.parameterType(4)).toString());
+        assertEquals("java.util.Map<?, ? super java.lang.String>",
+                genericTypeOf(m.parameterType(5)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A<java.lang.String>.B",
+                genericTypeOf(m.parameterType(6)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A<java.lang.String>.C<java.lang.String>",
+                genericTypeOf(m.parameterType(7)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$D",
+                genericTypeOf(m.parameterType(8)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$D$E",
+                genericTypeOf(m.parameterType(9)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$D.F<java.lang.String>",
+                genericTypeOf(m.parameterType(10)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$G<java.lang.String>",
+                genericTypeOf(m.parameterType(11)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$G$H<java.lang.String>",
+                genericTypeOf(m.parameterType(12)).toString());
+        assertEquals("org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$G<java.lang.String>.I",
+                genericTypeOf(m.parameterType(13)).toString());
+        assertEquals("T",
+                genericTypeOf(m.parameterType(14)).toString());
+        assertEquals("java.util.List<? super T>",
+                genericTypeOf(m.parameterType(15)).toString());
+    }
+
+    @Test
+    public void genericTypeWithAnnotationsFromType() throws IOException {
+        Index index = Index.of(MyAnn.class, FooBar.class);
+        ClassInfo clazz = index.getClassByName(FooBar.class);
+        assertNotNull(clazz);
+        MethodInfo m = clazz.firstMethod("foobar");
+        assertNotNull(m);
+        assertEquals(
+                "@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(1) int",
+                genericTypeOf(m.parameterType(0), index).toString());
+        assertEquals(
+                "java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(2) String",
+                genericTypeOf(m.parameterType(1), index).toString());
+        assertEquals(
+                "java.util.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(3) List<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(4) String>",
+                genericTypeOf(m.parameterType(2), index).toString());
+        assertEquals(
+                "java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(5) String[] @org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(6) []",
+                genericTypeOf(m.parameterType(3), index).toString());
+        assertEquals(
+                "java.util.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(7) List<@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(8) ? extends java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(9) String>",
+                genericTypeOf(m.parameterType(4), index).toString());
+        assertEquals(
+                "java.util.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(10) Map<@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(11) ?, @org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(12) ? super java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(13) String>",
+                genericTypeOf(m.parameterType(5), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(14) Jandex2GizmoTest$A<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(15) String>.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(16) B",
+                genericTypeOf(m.parameterType(6), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(17) Jandex2GizmoTest$A<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(18) String>.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(19) C<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(20) String>",
+                genericTypeOf(m.parameterType(7), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(21) Jandex2GizmoTest$A$D",
+                genericTypeOf(m.parameterType(8), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(22) Jandex2GizmoTest$A$D$E",
+                genericTypeOf(m.parameterType(9), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(23) Jandex2GizmoTest$A$D.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(24) F<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(25) String>",
+                genericTypeOf(m.parameterType(10), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(26) Jandex2GizmoTest$A$G<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(27) String>",
+                genericTypeOf(m.parameterType(11), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$G$H<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(28) String>",
+                genericTypeOf(m.parameterType(12), index).toString());
+        assertEquals(
+                "org.jboss.jandex.gizmo2.Jandex2GizmoTest$A$G<java.lang.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(29) String>.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(30) I",
+                genericTypeOf(m.parameterType(13), index).toString());
+        assertEquals(
+                "@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(31) T",
+                genericTypeOf(m.parameterType(14), index).toString());
+        assertEquals(
+                "java.util.@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(32) List<@org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(33) ? super @org.jboss.jandex.gizmo2.Jandex2GizmoTest$MyAnn(34) T>",
+                genericTypeOf(m.parameterType(15), index).toString());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <version.bytebuddy>1.17.6</version.bytebuddy>
         <version.exec-maven-plugin>3.5.1</version.exec-maven-plugin>
+        <version.gizmo2>2.0.0.Beta2</version.gizmo2>
         <version.groovy>4.0.27</version.groovy>
         <version.junit>5.13.3</version.junit>
         <version.maven>3.9.11</version.maven>
@@ -75,6 +76,11 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.quarkus.gizmo</groupId>
+                <artifactId>gizmo2</artifactId>
+                <version>${version.gizmo2}</version>
+            </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
@@ -179,6 +185,16 @@
                 <!-- setting this in a profile because the Java 8 compiler doesn't know the `release` option -->
                 <maven.compiler.release>8</maven.compiler.release>
             </properties>
+        </profile>
+
+        <profile>
+            <id>gizmo2-module</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>gizmo2</module>
+            </modules>
         </profile>
 
         <profile>


### PR DESCRIPTION
The `gizmo2` module is added which hosts the Gizmo 2 integration. It depends both on Jandex (core) and Gizmo 2. Since Gizmo 2 is a Java 17 project, this new module is also a Java 17 project. The rest of Jandex remains on Java 8.

The `Jandex2Gizmo` class contains `static` methods to create Gizmo types (`ClassDesc`, `GenericType` etc.) from Jandex types (`DotName`, `Type` etc.).

Resolves #544