### PR TITLE
cache and precompute array type names for the most common cases

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassType.java
+++ b/core/src/main/java/org/jboss/jandex/ClassType.java
@@ -31,6 +31,7 @@ public final class ClassType extends Type {
     public static final ClassType OBJECT_TYPE = new ClassType(DotName.OBJECT_NAME);
     public static final ClassType STRING_TYPE = new ClassType(DotName.STRING_NAME);
     public static final ClassType CLASS_TYPE = new ClassType(DotName.CLASS_NAME);
+    public static final ClassType ANNOTATION_TYPE = new ClassType(DotName.ANNOTATION_NAME);
 
     public static final ClassType BYTE_CLASS = new ClassType(DotName.BYTE_CLASS_NAME);
     public static final ClassType CHARACTER_CLASS = new ClassType(DotName.CHARACTER_CLASS_NAME);

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -51,6 +51,7 @@ public final class DotName implements Comparable<DotName> {
     public static final DotName ENUM_NAME;
     public static final DotName RECORD_NAME;
     public static final DotName STRING_NAME;
+    public static final DotName ANNOTATION_NAME;
 
     public static final DotName BOOLEAN_CLASS_NAME;
     public static final DotName BYTE_CLASS_NAME;
@@ -82,6 +83,7 @@ public final class DotName implements Comparable<DotName> {
         ENUM_NAME = createComponentized(JAVA_LANG_NAME, "Enum");
         RECORD_NAME = createComponentized(JAVA_LANG_NAME, "Record");
         STRING_NAME = createComponentized(JAVA_LANG_NAME, "String");
+        ANNOTATION_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Annotation");
 
         BOOLEAN_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Boolean");
         BYTE_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Byte");

--- a/core/src/test/java/org/jboss/jandex/test/ArrayTypeTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/ArrayTypeTest.java
@@ -92,4 +92,29 @@ public class ArrayTypeTest {
         assertEquals(kkkType, ArrayType.builder(PrimitiveType.BOOLEAN, 2).build());
     }
 
+    @Test
+    public void testPrecomputedNames() {
+        assertEquals("[Z", ArrayType.create(PrimitiveType.BOOLEAN, 1).name().toString());
+        assertEquals("[B", ArrayType.create(PrimitiveType.BYTE, 1).name().toString());
+        assertEquals("[S", ArrayType.create(PrimitiveType.SHORT, 1).name().toString());
+        assertEquals("[I", ArrayType.create(PrimitiveType.INT, 1).name().toString());
+        assertEquals("[J", ArrayType.create(PrimitiveType.LONG, 1).name().toString());
+        assertEquals("[F", ArrayType.create(PrimitiveType.FLOAT, 1).name().toString());
+        assertEquals("[D", ArrayType.create(PrimitiveType.DOUBLE, 1).name().toString());
+        assertEquals("[C", ArrayType.create(PrimitiveType.CHAR, 1).name().toString());
+
+        assertEquals("[Ljava.lang.Boolean;", ArrayType.create(ClassType.BOOLEAN_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Byte;", ArrayType.create(ClassType.BYTE_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Short;", ArrayType.create(ClassType.SHORT_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Integer;", ArrayType.create(ClassType.INTEGER_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Long;", ArrayType.create(ClassType.LONG_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Float;", ArrayType.create(ClassType.FLOAT_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Double;", ArrayType.create(ClassType.DOUBLE_CLASS, 1).name().toString());
+        assertEquals("[Ljava.lang.Character;", ArrayType.create(ClassType.CHARACTER_CLASS, 1).name().toString());
+
+        assertEquals("[Ljava.lang.Object;", ArrayType.create(ClassType.OBJECT_TYPE, 1).name().toString());
+        assertEquals("[Ljava.lang.String;", ArrayType.create(ClassType.STRING_TYPE, 1).name().toString());
+        assertEquals("[Ljava.lang.Class;", ArrayType.create(ClassType.CLASS_TYPE, 1).name().toString());
+        assertEquals("[Ljava.lang.annotation.Annotation;", ArrayType.create(ClassType.ANNOTATION_TYPE, 1).name().toString());
+    }
 }


### PR DESCRIPTION
Names of the following single-dimensional array types are cached:

- primitive types
- primitive wrapper classes
- `Object`, `String`, `Class`, `Annotation` class types

Further, names of the following single-dimensional array types are precomputed:

- other `java.*` class types

Other array types compute their name lazily, when `name()` is called.

Fixes #560