### PR TITLE
add `MethodSignatureKey`

### DIFF
--- a/core/src/main/java/org/jboss/jandex/FieldInfo.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInfo.java
@@ -428,6 +428,7 @@ public final class FieldInfo implements Declaration, Descriptor, GenericSignatur
      *
      * @return the bytecode descriptor of this field
      */
+    @Override
     public String descriptor(Function<String, Type> typeVariableSubstitution) {
         return DescriptorReconstruction.fieldDescriptor(this, typeVariableSubstitution);
     }

--- a/core/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -674,6 +674,7 @@ public final class MethodInfo implements Declaration, Descriptor, GenericSignatu
      *
      * @return the bytecode descriptor of this method
      */
+    @Override
     public String descriptor(Function<String, Type> typeVariableSubstitution) {
         return DescriptorReconstruction.methodDescriptor(this, typeVariableSubstitution);
     }

--- a/core/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -680,6 +680,15 @@ public final class MethodInfo implements Declaration, Descriptor, GenericSignatu
     }
 
     /**
+     * Returns a {@linkplain MethodSignatureKey signature key} for this method.
+     *
+     * @return {@link MethodSignatureKey} for this method, never {@code null}
+     */
+    public MethodSignatureKey signatureKey() {
+        return MethodSignatureKey.of(this);
+    }
+
+    /**
      * Returns a string representation describing this method. It is similar although not
      * necessarily identical to a Java source code declaration of this method.
      *

--- a/core/src/main/java/org/jboss/jandex/MethodSignatureKey.java
+++ b/core/src/main/java/org/jboss/jandex/MethodSignatureKey.java
@@ -1,0 +1,136 @@
+package org.jboss.jandex;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Opaque token that stands in for a method and implements equality and hash code based on
+ * a method signature. Method signature includes its name, parameter types and return type.
+ * Everything else is ignored, including the declaring class, type parameters, thrown types,
+ * visibility, etc.
+ * <p>
+ * Note that method signature keys are <em>not</em> sufficient to detect whether some
+ * method overrides another per the Java Language Specification rules.
+ * <p>
+ * <b>Thread-Safety</b>
+ * </p>
+ * This class is immutable and can be shared between threads without safe
+ * publication.
+ */
+public final class MethodSignatureKey {
+    private static final DotName[] NO_PARAMS = new DotName[0];
+
+    private static final Map<MethodInfo, MethodSignatureKey> JAVA_METHOD_SIGNATURES = new ConcurrentHashMap<>();
+
+    private static final MethodSignatureKey INIT_NO_ARGS = new MethodSignatureKey(Utils.INIT_METHOD_NAME,
+            NO_PARAMS, VoidType.VOID.name());
+    private static final MethodSignatureKey TO_STRING = new MethodSignatureKey(Utils.TO_STRING_METHOD_NAME,
+            NO_PARAMS, DotName.STRING_NAME);
+    private static final MethodSignatureKey EQUALS = new MethodSignatureKey(Utils.EQUALS_METHOD_NAME,
+            new DotName[] { DotName.OBJECT_NAME }, PrimitiveType.BOOLEAN.name());
+    private static final MethodSignatureKey HASH_CODE = new MethodSignatureKey(Utils.HASH_CODE_METHOD_NAME,
+            NO_PARAMS, PrimitiveType.INT.name());
+
+    private final byte[] name;
+    private final DotName[] parameterTypes;
+    private final DotName returnType;
+    private final int hashCode;
+
+    private static final Function<MethodInfo, MethodSignatureKey> CREATE_METHOD_SIGNATURE = new Function<MethodInfo, MethodSignatureKey>() {
+        @Override
+        public MethodSignatureKey apply(MethodInfo method) {
+            MethodInternal internal = method.methodInternal();
+
+            MethodSignatureKey staticEntry = getStaticEntry(internal);
+            if (staticEntry != null) {
+                return staticEntry;
+            }
+
+            Type[] arr = internal.parameterTypesArray();
+            DotName[] paramTypes;
+            if (arr.length > 0) {
+                paramTypes = new DotName[arr.length];
+                for (int i = 0; i < paramTypes.length; i++) {
+                    paramTypes[i] = arr[i].name();
+                }
+            } else {
+                paramTypes = NO_PARAMS;
+            }
+
+            return new MethodSignatureKey(internal.nameBytes(), paramTypes, internal.returnType().name());
+        }
+    };
+
+    static MethodSignatureKey of(MethodInfo method) {
+        if (method.declaringClass().name().startsWithJava()) {
+            return JAVA_METHOD_SIGNATURES.computeIfAbsent(method, CREATE_METHOD_SIGNATURE);
+        }
+        return CREATE_METHOD_SIGNATURE.apply(method);
+    }
+
+    private static MethodSignatureKey getStaticEntry(MethodInternal internal) {
+        byte[] name = internal.nameBytes();
+        DotName returnType = internal.returnType().name();
+        Type[] parameterTypes = internal.parameterTypesArray();
+
+        if (parameterTypes.length == 0) {
+            if (Arrays.equals(INIT_NO_ARGS.name, name)
+                    && INIT_NO_ARGS.returnType.equals(returnType)) {
+                return INIT_NO_ARGS;
+            }
+            if (Arrays.equals(TO_STRING.name, name)
+                    && TO_STRING.returnType.equals(returnType)) {
+                return TO_STRING;
+            }
+            if (Arrays.equals(HASH_CODE.name, name)
+                    && HASH_CODE.returnType.equals(returnType)) {
+                return HASH_CODE;
+            }
+        }
+
+        if (parameterTypes.length == 1) {
+            if (Arrays.equals(EQUALS.name, name)
+                    && EQUALS.returnType.equals(returnType)
+                    && EQUALS.parameterTypes[0].equals(parameterTypes[0].name())) {
+                return EQUALS;
+            }
+        }
+
+        return null;
+    }
+
+    private MethodSignatureKey(byte[] name, DotName[] parameterTypes, DotName returnType) {
+        this.name = name;
+        this.parameterTypes = parameterTypes;
+        this.returnType = returnType;
+        this.hashCode = computeHashCode(this.name, parameterTypes, returnType);
+    }
+
+    private static int computeHashCode(byte[] name, DotName[] paramTypes, DotName returnType) {
+        int result = Arrays.hashCode(name);
+        result = 31 * result + Arrays.hashCode(paramTypes);
+        result = 31 * result + returnType.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MethodSignatureKey)) {
+            return false;
+        }
+        MethodSignatureKey that = (MethodSignatureKey) o;
+        return Arrays.equals(name, that.name)
+                && Arrays.equals(parameterTypes, that.parameterTypes)
+                && returnType.equals(that.returnType);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/PrimitiveType.java
+++ b/core/src/main/java/org/jboss/jandex/PrimitiveType.java
@@ -18,7 +18,6 @@
 package org.jboss.jandex;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -82,21 +81,28 @@ public final class PrimitiveType extends Type {
      */
     public enum Primitive {
         /** Indicates a primitive byte type */
-        BYTE,
+        BYTE("byte"),
         /** Indicates a primitive character type */
-        CHAR,
+        CHAR("char"),
         /** Indicates a primitive double type */
-        DOUBLE,
+        DOUBLE("double"),
         /** Indicates a primitive float type */
-        FLOAT,
+        FLOAT("float"),
         /** Indicates a primitive integer type */
-        INT,
+        INT("int"),
         /** Indicates a primitive long type */
-        LONG,
+        LONG("long"),
         /** Indicates a primitive short type */
-        SHORT,
+        SHORT("short"),
         /** Indicates a primitive boolean type */
-        BOOLEAN,
+        BOOLEAN("boolean"),
+        ;
+
+        private final DotName dotName;
+
+        Primitive(String keyword) {
+            this.dotName = new DotName(null, keyword, true, false);
+        }
     }
 
     private final Primitive primitive;
@@ -106,7 +112,7 @@ public final class PrimitiveType extends Type {
     }
 
     private PrimitiveType(Primitive primitive, AnnotationInstance[] annotations) {
-        super(new DotName(null, primitive.name().toLowerCase(Locale.ENGLISH), true, false), annotations);
+        super(primitive.dotName, annotations);
         this.primitive = primitive;
     }
 

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -608,6 +608,7 @@ public abstract class Type implements Descriptor {
      *
      * @return the bytecode descriptor of this type (or its erasure in case of generic types)
      */
+    @Override
     public String descriptor(Function<String, Type> typeVariableSubstitution) {
         StringBuilder result = new StringBuilder();
         DescriptorReconstruction.typeDescriptor(this, typeVariableSubstitution, result);

--- a/core/src/main/java/org/jboss/jandex/Utils.java
+++ b/core/src/main/java/org/jboss/jandex/Utils.java
@@ -40,6 +40,10 @@ class Utils {
 
     static final byte[] CLINIT_METHOD_NAME = Utils.toUTF8("<clinit>");
 
+    static final byte[] EQUALS_METHOD_NAME = Utils.toUTF8("equals");
+    static final byte[] HASH_CODE_METHOD_NAME = Utils.toUTF8("hashCode");
+    static final byte[] TO_STRING_METHOD_NAME = Utils.toUTF8("toString");
+
     static byte[] toUTF8(String string) {
         return string.getBytes(StandardCharsets.UTF_8);
     }

--- a/core/src/main/java/org/jboss/jandex/VoidType.java
+++ b/core/src/main/java/org/jboss/jandex/VoidType.java
@@ -25,10 +25,12 @@ package org.jboss.jandex;
  * @author Jason T. Greene
  */
 public class VoidType extends Type {
+    private static final DotName VOID_NAME = new DotName(null, "void", true, false);
+
     public static final VoidType VOID = new VoidType(null);
 
     private VoidType(AnnotationInstance[] annotations) {
-        super(new DotName(null, "void", true, false), annotations);
+        super(VOID_NAME, annotations);
     }
 
     @Override

--- a/core/src/test/java/org/jboss/jandex/test/MethodSignatureKeyTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/MethodSignatureKeyTest.java
@@ -1,0 +1,145 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MethodSignatureKeyTest {
+    private Index index;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        index = Index.of(SomeClass.class, SuperClass.class, SuperSuperClass.class, TheRoot.class);
+    }
+
+    private Set<MethodSignatureKey> allMethodsOf(Class<?>... classes) {
+        return Arrays.stream(classes)
+                .map(index::getClassByName)
+                .map(ClassInfo::methods)
+                .flatMap(List::stream)
+                .map(MethodInfo::signatureKey)
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void shouldFindDirectOverriding() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("fromSuperClass");
+
+        assertTrue(methods.contains(parentMethod.signatureKey()));
+    }
+
+    @Test
+    public void shouldFindGenericOverriding() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo genericMethod = index.getClassByName(SuperSuperClass.class).firstMethod("generic");
+
+        assertTrue(methods.contains(genericMethod.signatureKey()));
+    }
+
+    @Test
+    public void shouldNotFindNonOverriddenFromSuperClass() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("notOverriddenFromSuperClass");
+
+        assertFalse(methods.contains(parentMethod.signatureKey()));
+    }
+
+    @Test
+    public void shouldNotFindNonGenericNonOverriddenFromSuperSuperClass() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverriddenNonGeneric");
+
+        assertFalse(methods.contains(parentMethod.signatureKey()));
+    }
+
+    @Test
+    public void shouldNotFindGenericNonOverriddenFromSuperSuperClass() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverriddenGeneric");
+
+        assertFalse(methods.contains(parentMethod.signatureKey()));
+    }
+
+    @Test
+    public void shouldNotFindAlmostMatchingGeneric() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("almostMatchingGeneric");
+
+        assertFalse(methods.contains(parentMethod.signatureKey()));
+    }
+
+    @Test
+    public void shouldFindOverriddenInTheMiddleOfHierarchy() {
+        Set<MethodSignatureKey> methods = allMethodsOf(SomeClass.class, SuperClass.class, SuperSuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(TheRoot.class).firstMethod("generic");
+
+        assertTrue(methods.contains(parentMethod.signatureKey()));
+    }
+
+    public static class SomeClass extends SuperClass<Boolean> {
+        @Override
+        void generic(Integer param) {
+        }
+
+        @Override
+        void nonGeneric(String param) {
+        }
+
+        @Override
+        void fromSuperClass(int param) {
+        }
+    }
+
+    public static class SuperClass<V> extends SuperSuperClass<Integer, V> {
+        void fromSuperClass(int param) {
+        }
+
+        void notOverriddenFromSuperClass(int param) {
+        }
+
+        void almostMatchingGeneric(V param) {
+        }
+    }
+
+    public static class SuperSuperClass<V, U> extends TheRoot<String, U, V> {
+        void generic(V arg) {
+        }
+
+        void almostMatchingGeneric(Integer arg) {
+        }
+
+        void nonGeneric(String param) {
+        }
+
+        void notOverriddenGeneric(V arg) {
+        }
+
+        void notOverriddenNonGeneric(String param) {
+        }
+    }
+
+    public static class TheRoot<U, V, X> {
+        void generic(X param) {
+        }
+    }
+}


### PR DESCRIPTION
Method signature key is an opaque token that only provides equality and hash code. These operations are based on a method signature, that is, the method name, parameter types and return type. Everything else is ignored.

Fixes #561