### PR TITLE
Precompute names for 1D arrays of parameterized types and type variables

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ArrayType.java
+++ b/core/src/main/java/org/jboss/jandex/ArrayType.java
@@ -135,13 +135,15 @@ public final class ArrayType extends Type {
 
     // precomputes the array type name for single-dimensional arrays of primitive types and `java.*` class types
     // the names of arrays of primitive types and a few common `java.*` class types are cached
-    // if the array type is not common, this method returns `DotName.OBJECT_NAME`, which is later checked by `name()`
+    // if the name is not precomputed, this method returns `DotName.OBJECT_NAME`, which is later checked by `name()`
     // this method is guaranteed to not allocate in case it decides to not precompute the array type name
     private static DotName precomputeName(Type constituent, int dimensions) {
         if (dimensions == 1) {
             if (constituent.kind() == Kind.PRIMITIVE) {
                 return PRIMITIVE_ARRAY_NAMES.get(constituent.asPrimitiveType().primitive());
-            } else if (constituent.kind() == Kind.CLASS) {
+            } else if (constituent.kind() == Kind.CLASS
+                    || constituent.kind() == Kind.PARAMETERIZED_TYPE
+                    || constituent.kind() == Kind.TYPE_VARIABLE) {
                 DotName name = constituent.name();
                 DotName known = COMMON_CLASS_ARRAY_NAMES.get(name);
                 if (known != null) {

--- a/core/src/test/java/org/jboss/jandex/test/ArrayTypeTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/ArrayTypeTest.java
@@ -3,13 +3,16 @@ package org.jboss.jandex.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.Index;
+import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
 import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
@@ -116,5 +119,12 @@ public class ArrayTypeTest {
         assertEquals("[Ljava.lang.String;", ArrayType.create(ClassType.STRING_TYPE, 1).name().toString());
         assertEquals("[Ljava.lang.Class;", ArrayType.create(ClassType.CLASS_TYPE, 1).name().toString());
         assertEquals("[Ljava.lang.annotation.Annotation;", ArrayType.create(ClassType.ANNOTATION_TYPE, 1).name().toString());
+
+        assertEquals("[Ljava.util.List;",
+                ArrayType.create(ParameterizedType.create(List.class, ClassType.create(String.class)), 1).name().toString());
+
+        assertEquals("[Ljava.lang.Object;", ArrayType.create(TypeVariable.create("T"), 1).name().toString());
+        assertEquals("[Ljava.lang.Number;",
+                ArrayType.create(TypeVariable.builder("T").addBound(Number.class).build(), 1).name().toString());
     }
 }


### PR DESCRIPTION
In my case, it was still responsible for quite a lot of allocations.

It allows to handle T[] as [Ljava.lang.Object; more efficiently.

This is a follow-up of https://github.com/smallrye/jandex/pull/562 .