### PR TITLE
Avoid using componentized DotNames for usual suspects

### DIFF
--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -74,30 +74,30 @@ public final class DotName implements Comparable<DotName> {
     private final boolean innerClass;
 
     static {
-        JAVA_NAME = createComponentized(null, "java");
-        JAVA_LANG_NAME = createComponentized(JAVA_NAME, "lang");
-        JAVA_LANG_ANNOTATION_NAME = createComponentized(JAVA_LANG_NAME, "annotation");
+        JAVA_NAME = createSimple("java");
+        JAVA_LANG_NAME = createSimple("java.lang");
+        JAVA_LANG_ANNOTATION_NAME = createSimple("annotation");
 
-        OBJECT_NAME = createComponentized(JAVA_LANG_NAME, "Object");
-        CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Class");
-        ENUM_NAME = createComponentized(JAVA_LANG_NAME, "Enum");
-        RECORD_NAME = createComponentized(JAVA_LANG_NAME, "Record");
-        STRING_NAME = createComponentized(JAVA_LANG_NAME, "String");
-        ANNOTATION_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Annotation");
+        OBJECT_NAME = createSimple("java.lang.Object");
+        CLASS_NAME = createSimple("java.lang.Class");
+        ENUM_NAME = createSimple("java.lang.Enum");
+        RECORD_NAME = createSimple("java.lang.Record");
+        STRING_NAME = createSimple("java.lang.String");
+        ANNOTATION_NAME = createSimple("java.lang.annotation.Annotation");
 
-        BOOLEAN_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Boolean");
-        BYTE_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Byte");
-        SHORT_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Short");
-        INTEGER_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Integer");
-        LONG_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Long");
-        FLOAT_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Float");
-        DOUBLE_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Double");
-        CHARACTER_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Character");
-        VOID_CLASS_NAME = createComponentized(JAVA_LANG_NAME, "Void");
+        BOOLEAN_CLASS_NAME = createSimple("java.lang.Boolean");
+        BYTE_CLASS_NAME = createSimple("java.lang.Byte");
+        SHORT_CLASS_NAME = createSimple("java.lang.Short");
+        INTEGER_CLASS_NAME = createSimple("java.lang.Integer");
+        LONG_CLASS_NAME = createSimple("java.lang.Long");
+        FLOAT_CLASS_NAME = createSimple("java.lang.Float");
+        DOUBLE_CLASS_NAME = createSimple("java.lang.Double");
+        CHARACTER_CLASS_NAME = createSimple("java.lang.Character");
+        VOID_CLASS_NAME = createSimple("java.lang.Void");
 
-        INHERITED_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Inherited");
-        REPEATABLE_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Repeatable");
-        RETENTION_NAME = createComponentized(JAVA_LANG_ANNOTATION_NAME, "Retention");
+        INHERITED_NAME = createSimple("java.lang.annotation.Inherited");
+        REPEATABLE_NAME = createSimple("java.lang.annotation.Repeatable");
+        RETENTION_NAME = createSimple("java.lang.annotation.Retention");
     }
 
     /**
@@ -326,7 +326,7 @@ public final class DotName implements Comparable<DotName> {
      */
     public String toString(char delim) {
         if (componentized) {
-            StringBuilder builder = new StringBuilder();
+            StringBuilder builder = new StringBuilder(stringLength());
             buildString(delim, builder);
             return builder.toString();
         } else {
@@ -340,6 +340,13 @@ public final class DotName implements Comparable<DotName> {
             builder.append(innerClass ? '$' : delim);
         }
         builder.append(local);
+    }
+
+    private int stringLength() {
+        if (componentized && prefix != null) {
+            return prefix.stringLength() + 1 + local.length();
+        }
+        return local.length();
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/NameTable.java
+++ b/core/src/main/java/org/jboss/jandex/NameTable.java
@@ -36,6 +36,28 @@ class NameTable {
     private StrongInternPool<RecordComponentInternal> recordComponentPool = StrongInternPool.forRecordComponents();
     private Map<String, DotName> names = new HashMap<String, DotName>();
 
+    NameTable() {
+        // prepopulate with common entries
+        names.put("java.lang.Object", DotName.OBJECT_NAME);
+        names.put("java.lang.Class", DotName.CLASS_NAME);
+        names.put("java.lang.Enum", DotName.ENUM_NAME);
+        names.put("java.lang.Record", DotName.RECORD_NAME);
+        names.put("java.lang.String", DotName.STRING_NAME);
+        names.put("java.lang.annotation.Annotation", DotName.ANNOTATION_NAME);
+        names.put("java.lang.Boolean", DotName.BOOLEAN_CLASS_NAME);
+        names.put("java.lang.Byte", DotName.BYTE_CLASS_NAME);
+        names.put("java.lang.Short", DotName.SHORT_CLASS_NAME);
+        names.put("java.lang.Integer", DotName.INTEGER_CLASS_NAME);
+        names.put("java.lang.Long", DotName.LONG_CLASS_NAME);
+        names.put("java.lang.Float", DotName.FLOAT_CLASS_NAME);
+        names.put("java.lang.Double", DotName.DOUBLE_CLASS_NAME);
+        names.put("java.lang.Character", DotName.CHARACTER_CLASS_NAME);
+        names.put("java.lang.Void", DotName.VOID_CLASS_NAME);
+        names.put("java.lang.annotation.Inherited", DotName.INHERITED_NAME);
+        names.put("java.lang.annotation.Repeatable", DotName.REPEATABLE_NAME);
+        names.put("java.lang.annotation.Retention", DotName.RETENTION_NAME);
+    }
+
     DotName convertToName(String name) {
         return convertToName(name, '.');
     }

--- a/core/src/main/java/org/jboss/jandex/PrimitiveType.java
+++ b/core/src/main/java/org/jboss/jandex/PrimitiveType.java
@@ -106,7 +106,7 @@ public final class PrimitiveType extends Type {
     }
 
     private PrimitiveType(Primitive primitive, AnnotationInstance[] annotations) {
-        super(new DotName(null, primitive.name().toLowerCase(Locale.ENGLISH), true, false), annotations);
+        super(DotName.createSimple(primitive.name().toLowerCase(Locale.ENGLISH)), annotations);
         this.primitive = primitive;
     }
 


### PR DESCRIPTION
We are building StringBuilders again and again in DotName#toString() while I think it has little value to use componentized DotNames for these very common DotNames as long as we reuse the same instances everywhere, which is the case, if I'm not mistaken.

To be honest, I wonder if in some cases, it wouldn't have value to allow prepopulating the NameTable with additional common entries before the Index is read/built. Typically for the ArC annotations. I'm not sure it's either feasible or desirable but I thought I would put this idea there.

Note that this patch is very rough and doesn't pass CI (as you can't write the Index, there is an assert that checks that every name is componentized).
I'm pretty sure the issue is solvable but the idea for now is more to log this here to have a discussion.

@Ladicek don't hesitate to push back on this one if you're not convinced. This patch improves allocations a bit but I think we would need to push it further to better alleviate the issue.