### PR TITLE
Reduce allocations for AnnotationInstance.hashCode()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/AnnotationInstance.java
+++ b/core/src/main/java/org/jboss/jandex/AnnotationInstance.java
@@ -468,20 +468,20 @@ public final class AnnotationInstance {
                     break;
                 case METHOD:
                     result = 31 * result + target.asMethod().declaringClass().name().hashCode();
-                    result = 31 * result + target.asMethod().name().hashCode();
+                    result = 31 * result + Arrays.hashCode(target.asMethod().methodInternal().nameBytes());
                     break;
                 case FIELD:
                     result = 31 * result + target.asField().declaringClass().name().hashCode();
-                    result = 31 * result + target.asField().name().hashCode();
+                    result = 31 * result + Arrays.hashCode(target.asField().fieldInternal().nameBytes());
                     break;
                 case METHOD_PARAMETER:
                     result = 31 * result + target.asMethodParameter().method().declaringClass().name().hashCode();
-                    result = 31 * result + target.asMethodParameter().method().name().hashCode();
+                    result = 31 * result + Arrays.hashCode(target.asMethodParameter().method().methodInternal().nameBytes());
                     result = 31 * result + target.asMethodParameter().position();
                     break;
                 case RECORD_COMPONENT:
                     result = 31 * result + target.asRecordComponent().declaringClass().name().hashCode();
-                    result = 31 * result + target.asRecordComponent().name().hashCode();
+                    result = 31 * result + Arrays.hashCode(target.asRecordComponent().recordComponentInternal().nameBytes());
                     break;
                 case TYPE:
                     if (target.asType().target() != null) {

--- a/core/src/test/java/org/jboss/jandex/test/MutableAnnotationOverlayTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/MutableAnnotationOverlayTest.java
@@ -11,9 +11,11 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
@@ -178,8 +180,13 @@ public class MutableAnnotationOverlayTest {
                             }
                         }
                     } else { // just to test `annotationsWithRepeatable`, no other reason
-                        for (AnnotationInstance annotation : overlay.annotationsWithRepeatable(declaration,
-                                MyRepeatableAnnotation.DOT_NAME)) {
+                        List<AnnotationInstance> annotations = overlay
+                                .annotationsWithRepeatable(declaration, MyRepeatableAnnotation.DOT_NAME)
+                                .stream()
+                                // need to make sure the order is deterministic
+                                .sorted(Comparator.comparing(a -> a.value().asString()))
+                                .collect(Collectors.toList());
+                        for (AnnotationInstance annotation : annotations) {
                             assertNotNull(annotation.target());
                             values.append(annotation.value().asString()).append("_");
                         }


### PR DESCRIPTION
We avoid going from byte[] to String to compute the hashCode of method names and field names.

<img width="3335" height="1072" alt="Screenshot From 2025-08-26 11-11-52" src="https://github.com/user-attachments/assets/3aeb327a-d023-409b-95f1-0559bc5bf858" />
