### PR TITLE
skip annotations when computing a hash code of fields, methods and record components

### DIFF
--- a/core/src/main/java/org/jboss/jandex/FieldInternal.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInternal.java
@@ -97,7 +97,6 @@ final class FieldInternal {
         int result = Arrays.hashCode(name);
         result = 31 * result + type.hashCode();
         result = 31 * result + (int) flags;
-        result = 31 * result + Arrays.hashCode(annotations);
         return result;
     }
 

--- a/core/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -203,7 +203,6 @@ final class MethodInternal {
         result = 31 * result + Arrays.hashCode(exceptions);
         result = 31 * result + (extra != null && extra.receiverType != null ? extra.receiverType.hashCode() : 0);
         result = 31 * result + (extra != null ? Arrays.hashCode(extra.typeParameters) : 0);
-        result = 31 * result + (extra != null ? Arrays.hashCode(extra.annotations) : 0);
         result = 31 * result + (extra != null && extra.defaultValue != null ? extra.defaultValue.hashCode() : 0);
         result = 31 * result + (int) flags;
         return result;

--- a/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
+++ b/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
@@ -88,7 +88,6 @@ final class RecordComponentInternal {
     public int hashCode() {
         int result = Arrays.hashCode(name);
         result = 31 * result + type.hashCode();
-        result = 31 * result + Arrays.hashCode(annotations);
         return result;
     }
 


### PR DESCRIPTION
Computing a hash code of an `AnnotationInstance` is relatively expensive, but makes little sense as part of a hash code of `FieldInternal`, `MethodInternal` and `RecordComponentInternal`. This is because there should never be fields, methods and record components that are the same except annotations. Further, there's plenty other information in the field/method/record component hash code, so the impact on hash collisions should be minimal.

Resolves #574