### PR TITLE
Ensure that unannotated known class types are singletons

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -219,10 +219,10 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
             Map<DotName, List<AnnotationInstance>> annotations, boolean hasNoArgsConstructor) {
         Type[] interfaceTypes = new Type[interfaces.length];
         for (int i = 0; i < interfaces.length; i++) {
-            interfaceTypes[i] = new ClassType(interfaces[i]);
+            interfaceTypes[i] = ClassType.create(interfaces[i]);
         }
 
-        ClassType superClassType = superName == null ? null : new ClassType(superName);
+        ClassType superClassType = superName == null ? null : ClassType.create(superName);
         ClassInfo clazz = new ClassInfo(name, superClassType, flags, interfaceTypes, hasNoArgsConstructor);
         clazz.setAnnotations(annotations);
         return clazz;

--- a/core/src/main/java/org/jboss/jandex/ClassType.java
+++ b/core/src/main/java/org/jboss/jandex/ClassType.java
@@ -17,6 +17,10 @@
  */
 package org.jboss.jandex;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Represents a class type. Class types also include erasures of parameterized types.
  * <p>
@@ -43,6 +47,26 @@ public final class ClassType extends Type {
     public static final ClassType BOOLEAN_CLASS = new ClassType(DotName.BOOLEAN_CLASS_NAME);
     public static final ClassType VOID_CLASS = new ClassType(DotName.VOID_CLASS_NAME);
 
+    private static final Map<DotName, ClassType> KNOWN_TYPES;
+
+    static {
+        Map<DotName, ClassType> map = new HashMap<>();
+        map.put(DotName.OBJECT_NAME, OBJECT_TYPE);
+        map.put(DotName.STRING_NAME, STRING_TYPE);
+        map.put(DotName.CLASS_NAME, CLASS_TYPE);
+        map.put(DotName.ANNOTATION_NAME, ANNOTATION_TYPE);
+        map.put(DotName.BYTE_CLASS_NAME, BYTE_CLASS);
+        map.put(DotName.CHARACTER_CLASS_NAME, CHARACTER_CLASS);
+        map.put(DotName.DOUBLE_CLASS_NAME, DOUBLE_CLASS);
+        map.put(DotName.FLOAT_CLASS_NAME, FLOAT_CLASS);
+        map.put(DotName.INTEGER_CLASS_NAME, INTEGER_CLASS);
+        map.put(DotName.LONG_CLASS_NAME, LONG_CLASS);
+        map.put(DotName.SHORT_CLASS_NAME, SHORT_CLASS);
+        map.put(DotName.BOOLEAN_CLASS_NAME, BOOLEAN_CLASS);
+        map.put(DotName.VOID_CLASS_NAME, VOID_CLASS);
+        KNOWN_TYPES = Collections.unmodifiableMap(map);
+    }
+
     /**
      * Create an instance of a class type with given {@code name}.
      * <p>
@@ -55,7 +79,15 @@ public final class ClassType extends Type {
      * @since 3.0.4
      */
     public static ClassType create(DotName name) {
-        return new ClassType(name);
+        ClassType known = KNOWN_TYPES.get(name);
+        return known != null ? known : new ClassType(name);
+    }
+
+    static ClassType create(DotName name, AnnotationInstance[] annotations) {
+        if (annotations == null || annotations.length == 0) {
+            return create(name);
+        }
+        return new ClassType(name, annotations);
     }
 
     /**
@@ -110,11 +142,11 @@ public final class ClassType extends Type {
         return builder(DotName.createSimple(clazz.getName()));
     }
 
-    ClassType(DotName name) {
+    private ClassType(DotName name) {
         this(name, null);
     }
 
-    ClassType(DotName name, AnnotationInstance[] annotations) {
+    private ClassType(DotName name, AnnotationInstance[] annotations) {
         super(name, annotations);
     }
 
@@ -130,7 +162,7 @@ public final class ClassType extends Type {
 
     @Override
     Type copyType(AnnotationInstance[] newAnnotations) {
-        return new ClassType(name(), newAnnotations);
+        return create(name(), newAnnotations);
     }
 
     ParameterizedType toParameterizedType() {
@@ -154,7 +186,7 @@ public final class ClassType extends Type {
          * @return the built class type
          */
         public ClassType build() {
-            return new ClassType(name, annotationsArray());
+            return create(name, annotationsArray());
         }
 
     }

--- a/core/src/main/java/org/jboss/jandex/GenericSignatureParser.java
+++ b/core/src/main/java/org/jboss/jandex/GenericSignatureParser.java
@@ -350,7 +350,7 @@ class GenericSignatureParser {
             // A suffix is a parameterized type if it has typeParameters or it's owner is a parameterized type
             // The first parameterized type needs a standard class type for the owner
             if (type == null && types.length > 0) {
-                type = names.intern(new ClassType(name.prefix()));
+                type = names.intern(ClassType.create(name.prefix()));
             }
 
             if (type != null) {
@@ -358,7 +358,7 @@ class GenericSignatureParser {
             }
         }
         this.pos++; // ;
-        return type != null ? type : names.intern(new ClassType(name));
+        return type != null ? type : names.intern(ClassType.create(name));
     }
 
     private Type[] parseTypeArguments() {

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV1.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV1.java
@@ -122,13 +122,13 @@ final class IndexReaderV1 extends IndexReaderImpl {
             int numIntfs = stream.readPackedU32();
             List<Type> interfaces = new ArrayList<Type>(numIntfs);
             for (int j = 0; j < numIntfs; j++) {
-                interfaces.add(new ClassType(classTable[stream.readPackedU32()]));
+                interfaces.add(ClassType.create(classTable[stream.readPackedU32()]));
             }
 
             Type[] interfaceTypes = interfaces.toArray(new Type[interfaces.size()]);
 
             Map<DotName, List<AnnotationInstance>> annotations = new HashMap<DotName, List<AnnotationInstance>>();
-            Type superClassType = superName == null ? null : new ClassType(superName);
+            Type superClassType = superName == null ? null : ClassType.create(superName);
             ClassInfo clazz = new ClassInfo(name, superClassType, flags, interfaceTypes, hasNoArgsConstructor);
             classes.put(name, clazz);
             addClassToMap(subclasses, superName, clazz);

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -384,7 +384,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
             case CLASS: {
                 DotName name = nameTable[stream.readPackedU32()];
                 AnnotationInstance[] annotations = readAnnotations(stream, null);
-                return new ClassType(name, annotations);
+                return ClassType.create(name, annotations);
             }
             case ARRAY: {
                 int dimensions = stream.readPackedU32();

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -1334,7 +1334,7 @@ public final class Indexer {
                     // create a synthetic `ClassType` for the purpose of resolving the type path,
                     // which would fail on a `VoidType` if the path points to a nested type
                     // (this happens on inner class constructors with type annotations)
-                    Type newType = new ClassType(method.declaringClass().name());
+                    Type newType = ClassType.create(method.declaringClass().name());
                     newType = resolveTypePath(newType, typeAnnotationState);
                     returnType = returnType.copyType(newType.annotationArray());
                     // fixup, `resolveTypePath` sets `typeAnnotationState.target` to the synthetic `ClassType`
@@ -1411,7 +1411,7 @@ public final class Indexer {
                     }
                 }
                 if (outermost == null) {
-                    outermost = outermostName.equals(type.name()) ? type : intern(new ClassType(outermostName));
+                    outermost = outermostName.equals(type.name()) ? type : intern(ClassType.create(outermostName));
                 }
 
                 outermost = intern(outermost.addAnnotation(AnnotationInstance.create(typeAnnotationState.annotation, null)));
@@ -1637,7 +1637,7 @@ public final class Indexer {
 
             if (depth == 0) {
                 if (last == null) {
-                    last = intern(new ClassType(currentName));
+                    last = intern(ClassType.create(currentName));
                 }
 
                 last = resolveTypePath(last, typeAnnotationState);
@@ -1952,7 +1952,7 @@ public final class Indexer {
 
         Type[] exceptions = numExceptions <= 0 ? Type.EMPTY_ARRAY : new Type[numExceptions];
         for (int i = 0; i < numExceptions; i++) {
-            exceptions[i] = intern(new ClassType(decodeClassEntry(data.readUnsignedShort())));
+            exceptions[i] = intern(ClassType.create(decodeClassEntry(data.readUnsignedShort())));
         }
 
         // Do not overwrite a signature exception
@@ -2184,10 +2184,10 @@ public final class Indexer {
         List<Type> interfaces = new ArrayList<Type>(numInterfaces);
 
         for (int i = 0; i < numInterfaces; i++) {
-            interfaces.add(intern(new ClassType(decodeClassEntry(data.readUnsignedShort()))));
+            interfaces.add(intern(ClassType.create(decodeClassEntry(data.readUnsignedShort()))));
         }
         Type[] interfaceTypes = intern(interfaces.toArray(new Type[interfaces.size()]));
-        Type superClassType = superName == null ? null : intern(new ClassType(superName));
+        Type superClassType = superName == null ? null : intern(ClassType.create(superName));
 
         this.currentClass = new ClassInfo(thisName, superClassType, flags, interfaceTypes);
 
@@ -2453,7 +2453,7 @@ public final class Indexer {
                     ;
                 name = names.convertToName(descriptor.substring(start + 1, end), '/');
                 pos.i = end;
-                return names.intern(new ClassType(name));
+                return names.intern(ClassType.create(name));
             }
             case '[': {
                 int end = start;

--- a/core/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -340,7 +340,7 @@ final class MethodInternal {
             }
             return new ParameterizedType(clazz.name(), receiverTypeArguments, null);
         }
-        return new ClassType(clazz.name());
+        return ClassType.create(clazz.name());
     }
 
     final Type receiverTypeField() {

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -177,7 +177,7 @@ public abstract class Type implements Descriptor {
                         while (string.charAt(++end) != ';')
                             ;
 
-                        type = new ClassType(DotName.createSimple(string.substring(start + 1, end)));
+                        type = ClassType.create(DotName.createSimple(string.substring(start + 1, end)));
                         break;
                     default:
                         type = PrimitiveType.decode(string.charAt(start));
@@ -188,7 +188,7 @@ public abstract class Type implements Descriptor {
 
                 return new ArrayType(type, depth);
             case CLASS:
-                return new ClassType(name);
+                return ClassType.create(name);
             case PRIMITIVE:
                 return PrimitiveType.decode(name.toString());
             case VOID:

--- a/core/src/test/java/org/jboss/jandex/test/TypeWithoutAnnotationsTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeWithoutAnnotationsTest.java
@@ -106,7 +106,7 @@ public class TypeWithoutAnnotationsTest {
                 withoutAnnotations(clazz, "typeParameterWithMultipleBoundsFirstParameterized"));
         assertEquals("Y extends java.io.Serializable & java.lang.Comparable<Y>",
                 withoutAnnotations(clazz, "typeParameterWithMultipleBoundsSecondParameterized"));
-        assertEquals("? extends java.lang.Object",
+        assertEquals("?",
                 firstTypeArgumentWithoutAnnotations(clazz, "unboundedWildcard"));
         assertEquals("? extends java.lang.Number",
                 firstTypeArgumentWithoutAnnotations(clazz, "wildcardWithUpperBound"));


### PR DESCRIPTION
In particular, this commit prevents "changing" an unbounded wildcard `?` to `? extends java.lang.Object`. This was caused by a new `ClassType` instance being created for `java.lang.Object`, instead of reusing the singleton instance.