### PR TITLE
Support lookup of method using an override/overridden method

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -832,6 +832,35 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
         return methodPositions;
     }
 
+    final MethodInfo method(MethodInternal key) {
+        int i = Arrays.binarySearch(methods, key, MethodInternal.NAME_AND_PARAMETER_COMPONENT_COMPARATOR);
+        return i >= 0 ? new MethodInfo(this, methods[i]) : null;
+    }
+
+    /**
+     * Retrieves a method that has the same signature as the given {@code other} method. The signature includes
+     * method name and parameter types; it does <em>not</em> include return type, type parameters or anything else.
+     * The parameter types are compared based on the underlying raw types. For example, an unbounded type parameter
+     * {@code T} is considered equal to {@code java.lang.Object}, since the raw form of a type variable is
+     * its upper bound.
+     * <p>
+     * Eligible methods include constructors and static initializers, which have the special names
+     * of {@code <init>} and {@code <clinit>}, respectively. Eligible methods do <em>not</em> include
+     * inherited methods. These must be discovered by traversing the class hierarchy.
+     * <p>
+     * This method may be useful for retrieving overridden or overriding methods, but note that the definition
+     * of method override is more complex; notably, it includes method visibility. For example, a {@code private}
+     * method in a superclass is not overridden by a method with the same signature in a subclass.
+     *
+     * @param other method instance having the same signature to retrieve from this ClassInfo
+     * @return the located method or {@code null} if not found
+     *
+     * @since 3.5.2
+     */
+    public final MethodInfo method(MethodInfo other) {
+        return method(other.methodInternal());
+    }
+
     /**
      * Retrieves a method based on its signature, which includes a method name and a parameter type list.
      * The parameter type list is compared based on the underlying raw types. As an example,
@@ -849,8 +878,7 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
     public final MethodInfo method(String name, Type... parameters) {
         MethodInternal key = new MethodInternal(Utils.toUTF8(name), MethodInternal.EMPTY_PARAMETER_NAMES, parameters, null,
                 (short) 0);
-        int i = Arrays.binarySearch(methods, key, MethodInternal.NAME_AND_PARAMETER_COMPONENT_COMPARATOR);
-        return i >= 0 ? new MethodInfo(this, methods[i]) : null;
+        return method(key);
     }
 
     /**

--- a/core/src/test/java/org/jboss/jandex/test/MethodRetrievalByMethodTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/MethodRetrievalByMethodTest.java
@@ -1,0 +1,76 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Arrays;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.Test;
+
+public class MethodRetrievalByMethodTest {
+    static class Grandparent {
+        public void doSomething(String p1, int p2) {
+        }
+
+        public void doSomething(Object p) {
+        }
+
+        private Number hello() {
+            return 1;
+        }
+    }
+
+    static class Parent extends Grandparent {
+        @Override
+        public void doSomething(String p1, int p2) {
+        }
+
+        public void doSomething(int p1, String p2) {
+        }
+
+        private Integer hello() {
+            return 2;
+        }
+    }
+
+    static class Child extends Parent {
+        @Override
+        public void doSomething(String p1, int p2) {
+        }
+
+        private Long hello() {
+            return 3L;
+        }
+    }
+
+    @Test
+    void test() throws Exception {
+        Index index = Index.of(Grandparent.class, Parent.class, Child.class);
+
+        ClassInfo childClazz = index.getClassByName(Child.class);
+
+        MethodInfo doSomething = childClazz.firstMethod("doSomething");
+        MethodInfo hello = childClazz.firstMethod("hello");
+
+        for (Class<?> ancestor : Arrays.asList(Parent.class, Grandparent.class)) {
+            ClassInfo ancestorClazz = index.getClassByName(ancestor);
+
+            MethodInfo ancestorDoSomething = ancestorClazz.method(doSomething);
+            assertNotNull(ancestorDoSomething);
+            assertNotSame(doSomething, ancestorDoSomething);
+            assertEquals("doSomething", ancestorDoSomething.name());
+            assertEquals(String.class.getName(), ancestorDoSomething.parameterType(0).name().toString());
+            assertEquals("int", ancestorDoSomething.parameterType(1).name().toString());
+
+            MethodInfo ancestorHello = ancestorClazz.method(hello);
+            assertNotNull(ancestorHello);
+            assertNotSame(hello, ancestorHello);
+            assertEquals("hello", ancestorHello.name());
+            assertEquals(0, ancestorHello.parametersCount());
+        }
+    }
+}


### PR DESCRIPTION
Allow a method to be retrieved from `ClassInfo` using a provided `MethodInfo` as the lookup parameter. This is useful for finding override/overridden methods and it avoids allocation of `MethodInternal` objects and conversion of the search method's `name` to a String.

This is one of the items that would be useful to improve performance in SR OpenAPI. See smallrye/smallrye-open-api#2401.

The new method may be better named something else - not sure.