### PR TITLE
add access to repeatable annotations that doesn't require an index

### DIFF
--- a/core/src/main/java/org/jboss/jandex/AnnotationTarget.java
+++ b/core/src/main/java/org/jboss/jandex/AnnotationTarget.java
@@ -340,6 +340,72 @@ public interface AnnotationTarget {
     }
 
     /**
+     * Returns a list of instances of the specified repeatable annotation declared on this annotation target and
+     * nested annotation targets. The {@code target()} method of the returned annotation instances may be used
+     * to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    Collection<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName);
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this annotation target and
+     * nested annotation targets. The {@code target()} method of the returned annotation instances may be used
+     * to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(String, IndexView)
+     */
+    default Collection<AnnotationInstance> annotationsWithRepeatable(String annotationName, String containerAnnotationName) {
+        return annotationsWithRepeatable(DotName.createSimple(annotationName), DotName.createSimple(containerAnnotationName));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this annotation target and
+     * nested annotation targets. The {@code target()} method of the returned annotation instances may be used
+     * to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationType the type of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationType the type of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(Class, IndexView)
+     */
+    default Collection<AnnotationInstance> annotationsWithRepeatable(Class<? extends Annotation> annotationType,
+            Class<? extends Annotation> containerAnnotationType) {
+        return annotationsWithRepeatable(DotName.createSimple(annotationType.getName()),
+                DotName.createSimple(containerAnnotationType.getName()));
+    }
+
+    /**
      * Returns the annotation instances declared on this annotation target and nested annotation targets.
      * The {@code target()} method of the returned annotation instances may be used to determine the exact location
      * of the respective annotation instance.
@@ -492,6 +558,77 @@ public interface AnnotationTarget {
     default Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(Class<? extends Annotation> clazz,
             IndexView index) {
         return declaredAnnotationsWithRepeatable(DotName.createSimple(clazz.getName()), index);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this annotation target.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, DotName)}, this method doesn't return annotations
+     * declared on nested annotation targets.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName);
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this annotation target.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(String, String)}, this method doesn't return annotations
+     * declared on nested annotation targets.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(String, String)
+     */
+    default Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(String annotationName,
+            String containerAnnotationName) {
+        return declaredAnnotationsWithRepeatable(DotName.createSimple(annotationName),
+                DotName.createSimple(containerAnnotationName));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this annotation target.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(Class, Class)}, this method doesn't return annotations
+     * declared on nested annotation targets.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationType the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable collection of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(Class, Class)
+     */
+    default Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(Class<? extends Annotation> annotationType,
+            Class<? extends Annotation> containerAnnotationName) {
+        return declaredAnnotationsWithRepeatable(DotName.createSimple(annotationType.getName()),
+                DotName.createSimple(containerAnnotationName.getName()));
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -475,7 +475,6 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>(annotations(name));
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -484,12 +483,35 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            for (AnnotationInstance container : annotations(containingType.name())) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? annotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : annotations(name);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this class, any of its members,
+     * or any type within the signature of the class or its members. The {@code target()} method of the returned
+     * annotation instances may be used to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    @Override
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>(annotations(annotationName));
+        for (AnnotationInstance container : annotations(containerAnnotationName)) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);
@@ -598,11 +620,6 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>();
-        AnnotationInstance declaredInstance = declaredAnnotation(name);
-        if (declaredInstance != null) {
-            instances.add(declaredInstance);
-        }
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -611,13 +628,42 @@ public final class ClassInfo implements Declaration, Descriptor, GenericSignatur
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            AnnotationInstance container = declaredAnnotation(containingType.name());
-            if (container != null) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? declaredAnnotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : Utils.emptyOrSingletonList(declaredAnnotation(name));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this class.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, DotName)}, this method doesn't return annotations
+     * declared on nested annotation targets.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    @Override
+    public final List<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>();
+        AnnotationInstance declaredInstance = declaredAnnotation(annotationName);
+        if (declaredInstance != null) {
+            instances.add(declaredInstance);
+        }
+        AnnotationInstance container = declaredAnnotation(containerAnnotationName);
+        if (container != null) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);

--- a/core/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/core/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -89,6 +89,16 @@ public class CompositeIndex implements IndexView {
         return Collections.unmodifiableList(allInstances);
     }
 
+    @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> allInstances = new ArrayList<>();
+        for (IndexView i : indexes) {
+            allInstances.addAll(i.getAnnotationsWithRepeatable(annotationName, containerAnnotationName));
+        }
+        return Collections.unmodifiableList(allInstances);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/org/jboss/jandex/EmptyIndex.java
+++ b/core/src/main/java/org/jboss/jandex/EmptyIndex.java
@@ -77,6 +77,12 @@ public final class EmptyIndex implements IndexView {
     }
 
     @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        return Collections.emptySet();
+    }
+
+    @Override
     public Collection<ModuleInfo> getKnownModules() {
         return Collections.emptySet();
     }

--- a/core/src/main/java/org/jboss/jandex/FieldInfo.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInfo.java
@@ -190,7 +190,6 @@ public final class FieldInfo implements Declaration, Descriptor, GenericSignatur
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>(annotations(name));
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -199,12 +198,35 @@ public final class FieldInfo implements Declaration, Descriptor, GenericSignatur
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            for (AnnotationInstance container : annotations(containingType.name())) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? annotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : annotations(name);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this field or any type
+     * within its signature. The {@code target()} method of the returned annotation instances may be used
+     * to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    @Override
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>(annotations(annotationName));
+        for (AnnotationInstance container : annotations(containerAnnotationName)) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);
@@ -290,11 +312,6 @@ public final class FieldInfo implements Declaration, Descriptor, GenericSignatur
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>();
-        AnnotationInstance declaredInstance = declaredAnnotation(name);
-        if (declaredInstance != null) {
-            instances.add(declaredInstance);
-        }
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -303,13 +320,42 @@ public final class FieldInfo implements Declaration, Descriptor, GenericSignatur
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            AnnotationInstance container = declaredAnnotation(containingType.name());
-            if (container != null) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? declaredAnnotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : Utils.emptyOrSingletonList(declaredAnnotation(name));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this field.
+     * <p>
+     * The result contains the given annotation as well as all values of the given container annotation.
+     * In the latter case, the {@link AnnotationInstance#target()} returns the target of the container
+     * annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, DotName)}, this method doesn't return annotations
+     * declared on types within the field signature.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    @Override
+    public final List<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>();
+        AnnotationInstance declaredInstance = declaredAnnotation(annotationName);
+        if (declaredInstance != null) {
+            instances.add(declaredInstance);
+        }
+        AnnotationInstance container = declaredAnnotation(containerAnnotationName);
+        if (container != null) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);

--- a/core/src/main/java/org/jboss/jandex/Index.java
+++ b/core/src/main/java/org/jboss/jandex/Index.java
@@ -351,13 +351,18 @@ public final class Index implements IndexView {
             return getAnnotations(annotationName);
         }
         Type containing = repeatable.value().asClass();
-        return getRepeatableAnnotations(annotationName, containing.name());
+        return getAnnotationsWithRepeatable(annotationName, containing.name());
     }
 
-    private Collection<AnnotationInstance> getRepeatableAnnotations(DotName annotationName, DotName containingAnnotationName) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
         List<AnnotationInstance> instances = new ArrayList<AnnotationInstance>();
         instances.addAll(getAnnotations(annotationName));
-        for (AnnotationInstance containingInstance : getAnnotations(containingAnnotationName)) {
+        for (AnnotationInstance containingInstance : getAnnotations(containerAnnotationName)) {
             for (AnnotationInstance nestedInstance : containingInstance.value().asNestedArray()) {
                 // We need to set the target of the containing instance
                 instances.add(AnnotationInstance.create(nestedInstance, containingInstance.target()));

--- a/core/src/main/java/org/jboss/jandex/IndexView.java
+++ b/core/src/main/java/org/jboss/jandex/IndexView.java
@@ -492,6 +492,58 @@ public interface IndexView {
     }
 
     /**
+     * Obtains a list of instances of the specified repeatable annotation. The result contains
+     * all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns
+     * the target of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation
+     * @param containerAnnotationName the name of the container of the repeatable annotation
+     * @return immutable collection of annotation instances, never {@code null}
+     */
+    Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName);
+
+    /**
+     * Obtains a list of instances of the specified repeatable annotation. The result contains
+     * all occurrences of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns
+     * the target of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation
+     * @param containerAnnotationName the name of the container of the repeatable annotation
+     * @return immutable collection of annotation instances, never {@code null}
+     */
+    default Collection<AnnotationInstance> getAnnotationsWithRepeatable(String annotationName, String containerAnnotationName) {
+        return getAnnotationsWithRepeatable(DotName.createSimple(annotationName),
+                DotName.createSimple(containerAnnotationName));
+    }
+
+    /**
+     * Obtains a list of instances of the specified repeatable annotation. The result contains
+     * all occurrences of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns
+     * the target of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationType the name of the repeatable annotation
+     * @param containerAnnotationType the name of the container of the repeatable annotation
+     * @return immutable collection of annotation instances, never {@code null}
+     */
+    default Collection<AnnotationInstance> getAnnotationsWithRepeatable(Class<?> annotationType,
+            Class<?> containerAnnotationType) {
+        return getAnnotationsWithRepeatable(DotName.createSimple(annotationType.getName()),
+                DotName.createSimple(containerAnnotationType.getName()));
+    }
+
+    /**
      * Gets all known modules by this index (those which were scanned).
      *
      * @return immutable collection of known modules, never {@code null}

--- a/core/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -409,7 +409,6 @@ public final class MethodInfo implements Declaration, Descriptor, GenericSignatu
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>(annotations(name));
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -418,12 +417,35 @@ public final class MethodInfo implements Declaration, Descriptor, GenericSignatu
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            for (AnnotationInstance container : annotations(containingType.name())) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? annotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : annotations(name);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this method, any of its
+     * parameters or any type within its signature. The {@code target()} method of the returned annotation instances
+     * may be used to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    @Override
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>(annotations(annotationName));
+        for (AnnotationInstance container : annotations(containerAnnotationName)) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);
@@ -513,11 +535,6 @@ public final class MethodInfo implements Declaration, Descriptor, GenericSignatu
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>();
-        AnnotationInstance declaredInstance = declaredAnnotation(name);
-        if (declaredInstance != null) {
-            instances.add(declaredInstance);
-        }
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -526,13 +543,42 @@ public final class MethodInfo implements Declaration, Descriptor, GenericSignatu
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            AnnotationInstance container = declaredAnnotation(containingType.name());
-            if (container != null) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? declaredAnnotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : Utils.emptyOrSingletonList(declaredAnnotation(name));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this method.
+     * <p>
+     * The result contains the given annotation as well as all values of the given container annotation.
+     * In the latter case, the {@link AnnotationInstance#target()} returns the target of the container
+     * annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, DotName)}, this method doesn't return annotations
+     * declared on types within the field signature.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    @Override
+    public final List<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>();
+        AnnotationInstance declaredInstance = declaredAnnotation(annotationName);
+        if (declaredInstance != null) {
+            instances.add(declaredInstance);
+        }
+        AnnotationInstance container = declaredAnnotation(containerAnnotationName);
+        if (container != null) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);

--- a/core/src/main/java/org/jboss/jandex/MethodParameterInfo.java
+++ b/core/src/main/java/org/jboss/jandex/MethodParameterInfo.java
@@ -196,7 +196,6 @@ public final class MethodParameterInfo implements Declaration {
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>(annotations(name));
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -205,12 +204,35 @@ public final class MethodParameterInfo implements Declaration {
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            for (AnnotationInstance container : annotations(containingType.name())) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? annotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : annotations(name);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this method parameter or any type
+     * within its signature. The {@code target()} method of the returned annotation instances may be used
+     * to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    @Override
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>(annotations(annotationName));
+        for (AnnotationInstance container : annotations(containerAnnotationName)) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);
@@ -295,11 +317,6 @@ public final class MethodParameterInfo implements Declaration {
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>();
-        AnnotationInstance declaredInstance = declaredAnnotation(name);
-        if (declaredInstance != null) {
-            instances.add(declaredInstance);
-        }
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -308,13 +325,42 @@ public final class MethodParameterInfo implements Declaration {
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            AnnotationInstance container = declaredAnnotation(containingType.name());
-            if (container != null) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? declaredAnnotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : Utils.emptyOrSingletonList(declaredAnnotation(name));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this method parameter.
+     * <p>
+     * The result contains the given annotation as well as all values of the given container annotation.
+     * In the latter case, the {@link AnnotationInstance#target()} returns the target of the container
+     * annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, DotName)}, this method doesn't return annotations
+     * declared on types within the record component signature.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    @Override
+    public final List<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>();
+        AnnotationInstance declaredInstance = declaredAnnotation(annotationName);
+        if (declaredInstance != null) {
+            instances.add(declaredInstance);
+        }
+        AnnotationInstance container = declaredAnnotation(containerAnnotationName);
+        if (container != null) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);

--- a/core/src/main/java/org/jboss/jandex/ModuleInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ModuleInfo.java
@@ -154,8 +154,12 @@ public final class ModuleInfo {
         return moduleInfoClass.declaredAnnotation(name);
     }
 
-    public final List<AnnotationInstance> annotationsWithRepeatable(DotName name, IndexView index) {
-        return moduleInfoClass.declaredAnnotationsWithRepeatable(name, index);
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, IndexView index) {
+        return moduleInfoClass.declaredAnnotationsWithRepeatable(annotationName, index);
+    }
+
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        return moduleInfoClass.declaredAnnotationsWithRepeatable(annotationName, containerAnnotationName);
     }
 
     public final Collection<AnnotationInstance> annotations() {

--- a/core/src/main/java/org/jboss/jandex/RecordComponentInfo.java
+++ b/core/src/main/java/org/jboss/jandex/RecordComponentInfo.java
@@ -182,7 +182,6 @@ public final class RecordComponentInfo implements Declaration, Descriptor, Gener
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>(annotations(name));
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -191,12 +190,35 @@ public final class RecordComponentInfo implements Declaration, Descriptor, Gener
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            for (AnnotationInstance container : annotations(containingType.name())) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? annotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : annotations(name);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this record component or any type
+     * within its signature. The {@code target()} method of the returned annotation instances may be used
+     * to determine the exact location of the respective annotation instance.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    @Override
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>(annotations(annotationName));
+        for (AnnotationInstance container : annotations(containerAnnotationName)) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);
@@ -273,11 +295,6 @@ public final class RecordComponentInfo implements Declaration, Descriptor, Gener
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>();
-        AnnotationInstance declaredInstance = declaredAnnotation(name);
-        if (declaredInstance != null) {
-            instances.add(declaredInstance);
-        }
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -286,13 +303,42 @@ public final class RecordComponentInfo implements Declaration, Descriptor, Gener
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            AnnotationInstance container = declaredAnnotation(containingType.name());
-            if (container != null) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? declaredAnnotationsWithRepeatable(name, repeatable.value().asClass().name())
+                : Utils.emptyOrSingletonList(declaredAnnotation(name));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this record component.
+     * <p>
+     * The result contains the given annotation as well as all values of the given container annotation.
+     * In the latter case, the {@link AnnotationInstance#target()} returns the target of the container
+     * annotation instance.
+     * <p>
+     * Unlike {@link #annotationsWithRepeatable(DotName, DotName)}, this method doesn't return annotations
+     * declared on types within the record component signature.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    @Override
+    public final List<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>();
+        AnnotationInstance declaredInstance = declaredAnnotation(annotationName);
+        if (declaredInstance != null) {
+            instances.add(declaredInstance);
+        }
+        AnnotationInstance container = declaredAnnotation(containerAnnotationName);
+        if (container != null) {
+            for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, container.target()));
             }
         }
         return Collections.unmodifiableList(instances);

--- a/core/src/main/java/org/jboss/jandex/StackedIndex.java
+++ b/core/src/main/java/org/jboss/jandex/StackedIndex.java
@@ -284,6 +284,29 @@ public final class StackedIndex implements IndexView {
         return Collections.unmodifiableList(result);
     }
 
+    @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        List<AnnotationInstance> result = new ArrayList<>();
+        Set<DotName> seen = new HashSet<>();
+        Set<DotName> seenInThisIteration = new HashSet<>();
+        for (IndexView idx : stack) {
+            for (AnnotationInstance annotation : idx.getAnnotationsWithRepeatable(annotationName, containerAnnotationName)) {
+                DotName inClass = nameOfDeclaringClass(annotation.target());
+                if (inClass == null) {
+                    continue;
+                }
+                if (!seen.contains(inClass)) {
+                    result.add(annotation);
+                    seenInThisIteration.add(inClass);
+                }
+            }
+            seen.addAll(seenInThisIteration);
+            seenInThisIteration.clear();
+        }
+        return Collections.unmodifiableList(result);
+    }
+
     private static DotName nameOfDeclaringClass(AnnotationTarget target) {
         if (target == null) {
             return null;

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -484,11 +484,6 @@ public abstract class Type implements Descriptor {
         if (index == null) {
             throw new IllegalArgumentException("Index must not be null");
         }
-        List<AnnotationInstance> instances = new ArrayList<>();
-        AnnotationInstance declaredInstance = annotation(name);
-        if (declaredInstance != null) {
-            instances.add(declaredInstance);
-        }
         ClassInfo annotationClass = index.getClassByName(name);
         if (annotationClass == null) {
             throw new IllegalArgumentException("Index does not contain the annotation definition: " + name);
@@ -497,13 +492,37 @@ public abstract class Type implements Descriptor {
             throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
         }
         AnnotationInstance repeatable = annotationClass.declaredAnnotation(DotName.REPEATABLE_NAME);
-        if (repeatable != null) {
-            Type containingType = repeatable.value().asClass();
-            AnnotationInstance container = annotation(containingType.name());
-            if (container != null) {
-                for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
-                }
+        return repeatable != null
+                ? annotationsWithRepeatable(name, repeatable.value().asClass().name)
+                : Utils.emptyOrSingletonList(annotation(name));
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this type usage.
+     * <p>
+     * The result contains the given annotation as well as all values of the given container annotation.
+     * In the latter case, the {@link AnnotationInstance#target()} returns the target of the container
+     * annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<>();
+        AnnotationInstance ann = annotation(annotationName);
+        if (ann != null) {
+            instances.add(ann);
+        }
+        AnnotationInstance containerAnn = annotation(containerAnnotationName);
+        if (containerAnn != null) {
+            for (AnnotationInstance nestedInstance : containerAnn.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nestedInstance, containerAnn.target()));
             }
         }
         return Collections.unmodifiableList(instances);

--- a/core/src/main/java/org/jboss/jandex/TypeTarget.java
+++ b/core/src/main/java/org/jboss/jandex/TypeTarget.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.jandex;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -295,10 +296,34 @@ public abstract class TypeTarget implements AnnotationTarget {
      */
     @Override
     public List<AnnotationInstance> annotationsWithRepeatable(DotName name, IndexView index) {
-        if (target == null) {
-            return Collections.emptyList();
-        }
-        return target.annotationsWithRepeatable(name, index);
+        return target == null ? Collections.emptyList() : target.annotationsWithRepeatable(name, index);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this type usage.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * Note that unlike other {@code AnnotationTarget}s, this method doesn't inspect nested annotation targets,
+     * even though array types, parameterized types, type variables and wildcard types may contain other types
+     * inside them. In other words, this method is equivalent to {@link #declaredAnnotationsWithRepeatable(DotName, DotName)}.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, IndexView)
+     */
+    @Override
+    public Collection<AnnotationInstance> annotationsWithRepeatable(DotName annotationName, DotName containerAnnotationName) {
+        return target == null
+                ? Collections.emptyList()
+                : target.annotationsWithRepeatable(annotationName, containerAnnotationName);
     }
 
     /**
@@ -363,6 +388,28 @@ public abstract class TypeTarget implements AnnotationTarget {
     @Override
     public List<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName name, IndexView index) {
         return annotationsWithRepeatable(name, index);
+    }
+
+    /**
+     * Returns a list of instances of the specified repeatable annotation declared on this type usage.
+     * <p>
+     * The result contains all instances of the given annotation as well as all values of all instances of the given
+     * container annotation. In the latter case, the {@link AnnotationInstance#target()} returns the target
+     * of the container annotation instance.
+     * <p>
+     * WARNING: if the given {@code containerAnnotationName} doesn't name a container annotation for a repeatable
+     * annotation {@code annotationName}, the behavior of this method is <em>undefined</em>.
+     *
+     * @param annotationName the name of the repeatable annotation, must not be {@code null}
+     * @param containerAnnotationName the name of the container of the repeatable annotation, must not be {@code null}
+     * @return immutable list of annotation instances, never {@code null}
+     * @since 3.6
+     * @see #annotationsWithRepeatable(DotName, DotName)
+     */
+    @Override
+    public Collection<AnnotationInstance> declaredAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        return annotationsWithRepeatable(annotationName, containerAnnotationName);
     }
 
     /**

--- a/core/src/main/java/org/jboss/jandex/Utils.java
+++ b/core/src/main/java/org/jboss/jandex/Utils.java
@@ -76,6 +76,10 @@ class Utils {
         }
     }
 
+    static <T> List<T> emptyOrSingletonList(T itemOrNull) {
+        return itemOrNull != null ? Collections.singletonList(itemOrNull) : Collections.emptyList();
+    }
+
     static <T> List<T> listOfCapacity(int capacity) {
         return capacity > 0 ? new ArrayList<>(capacity) : Collections.emptyList();
     }

--- a/core/src/test/java/org/jboss/jandex/test/AnnotationAccessTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/AnnotationAccessTest.java
@@ -65,6 +65,7 @@ public class AnnotationAccessTest {
     public void test() throws IOException {
         DotName myAnn = MyAnnotation.DOT_NAME;
         DotName myRepAnn = MyRepeatableAnnotation.DOT_NAME;
+        DotName myRepAnnContainer = MyRepeatableAnnotation.List.DOT_NAME;
         DotName className = DotName.createSimple(AnnotatedClass.class.getName());
 
         Index index = Index.of(MyAnnotation.class, MyRepeatableAnnotation.class, MyRepeatableAnnotation.List.class,
@@ -86,8 +87,11 @@ public class AnnotationAccessTest {
             assertEquals(3, clazz.declaredAnnotations().size());
             verify(clazz.declaredAnnotations(), myAnn, "c1");
             assertEquals(9, clazz.annotationsWithRepeatable(myRepAnn, index).size());
+            assertEquals(9, clazz.annotationsWithRepeatable(myRepAnn, myRepAnnContainer).size());
             assertEquals(3, clazz.declaredAnnotationsWithRepeatable(myRepAnn, index).size());
+            assertEquals(3, clazz.declaredAnnotationsWithRepeatable(myRepAnn, myRepAnnContainer).size());
             verify(clazz.declaredAnnotationsWithRepeatable(myRepAnn, index), myRepAnn, "cr1", "cr2", "cr3");
+            verify(clazz.declaredAnnotationsWithRepeatable(myRepAnn, myRepAnnContainer), myRepAnn, "cr1", "cr2", "cr3");
         }
 
         {
@@ -104,8 +108,11 @@ public class AnnotationAccessTest {
             assertEquals(3, field.declaredAnnotations().size());
             verify(field.declaredAnnotations(), myAnn, "f1");
             assertEquals(3, field.annotationsWithRepeatable(myRepAnn, index).size());
+            assertEquals(3, field.annotationsWithRepeatable(myRepAnn, myRepAnnContainer).size());
             assertEquals(3, field.declaredAnnotationsWithRepeatable(myRepAnn, index).size());
+            assertEquals(3, field.declaredAnnotationsWithRepeatable(myRepAnn, myRepAnnContainer).size());
             verify(field.declaredAnnotationsWithRepeatable(myRepAnn, index), myRepAnn, "fr1", "fr2", "fr3");
+            verify(field.declaredAnnotationsWithRepeatable(myRepAnn, myRepAnnContainer), myRepAnn, "fr1", "fr2", "fr3");
         }
 
         {
@@ -133,8 +140,11 @@ public class AnnotationAccessTest {
             assertEquals(3, method.declaredAnnotations().size());
             verify(method.declaredAnnotations(), myAnn, "m1");
             assertEquals(3, method.annotationsWithRepeatable(myRepAnn, index).size());
+            assertEquals(3, method.annotationsWithRepeatable(myRepAnn, myRepAnnContainer).size());
             assertEquals(3, method.declaredAnnotationsWithRepeatable(myRepAnn, index).size());
+            assertEquals(3, method.declaredAnnotationsWithRepeatable(myRepAnn, myRepAnnContainer).size());
             verify(method.declaredAnnotationsWithRepeatable(myRepAnn, index), myRepAnn, "mr1", "mr2", "mr3");
+            verify(method.declaredAnnotationsWithRepeatable(myRepAnn, myRepAnnContainer), myRepAnn, "mr1", "mr2", "mr3");
         }
 
         {

--- a/core/src/test/java/org/jboss/jandex/test/AnnotationOverlayTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/AnnotationOverlayTest.java
@@ -427,6 +427,12 @@ public class AnnotationOverlayTest {
         }
 
         @Override
+        public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+                DotName containerAnnotationName) {
+            return delegate.getAnnotationsWithRepeatable(annotationName, containerAnnotationName);
+        }
+
+        @Override
         public Collection<ModuleInfo> getKnownModules() {
             return delegate.getKnownModules();
         }

--- a/core/src/test/java/org/jboss/jandex/test/EquivalenceTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/EquivalenceTest.java
@@ -130,11 +130,13 @@ public class EquivalenceTest {
             return null;
         }
 
-        @MyAnnotation("2") String[][] annotationOnElement() {
+        @MyAnnotation("2")
+        String[][] annotationOnElement() {
             return null;
         }
 
-        @MyAnnotation("3") String[] @MyAnnotation("4") [] annotationsOnBoth() {
+        @MyAnnotation("3")
+        String[] @MyAnnotation("4") [] annotationsOnBoth() {
             return null;
         }
     }

--- a/core/src/test/java/org/jboss/jandex/test/RepeatableAnnotationsTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/RepeatableAnnotationsTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.Type;
 import org.junit.jupiter.api.Test;
 
 public class RepeatableAnnotationsTestCase {
@@ -50,23 +49,31 @@ public class RepeatableAnnotationsTestCase {
     @Test
     public void testIndexView() throws IOException {
         Index index = getIndexForClass(MY_ANNOTATED_NAME, ALPHA_NAME);
-        Collection<AnnotationInstance> instances = index.getAnnotationsWithRepeatable(ALPHA_NAME, index);
-        assertEquals(10, instances.size());
-        assertValues(find(instances, Kind.CLASS, null), 0);
-        assertValues(find(instances, Kind.METHOD, "foo"), 1);
-        assertValues(find(instances, Kind.METHOD_PARAMETER, "fooName"), 11, 12);
-        assertValues(find(instances, Kind.METHOD, "bar"), 2, 3);
-        assertValues(find(instances, Kind.METHOD_PARAMETER, "barName"), 10);
-        // MyAnnotated.myField
-        assertValues(find(instances, Kind.FIELD, "myField"), -1, -2);
-        assertValues(find(instances, Kind.FIELD, "anotherField"), -3);
+        assertIndexView(index.getAnnotationsWithRepeatable(ALPHA_NAME, index));
+        assertIndexView(index.getAnnotationsWithRepeatable(ALPHA_NAME, ALPHA_CONTAINER_NAME));
+    }
+
+    private void assertIndexView(Collection<AnnotationInstance> annotations) {
+        assertEquals(10, annotations.size());
+        assertValues(find(annotations, Kind.CLASS, null), 0);
+        assertValues(find(annotations, Kind.METHOD, "foo"), 1);
+        assertValues(find(annotations, Kind.METHOD_PARAMETER, "fooName"), 11, 12);
+        assertValues(find(annotations, Kind.METHOD, "bar"), 2, 3);
+        assertValues(find(annotations, Kind.METHOD_PARAMETER, "barName"), 10);
+        assertValues(find(annotations, Kind.FIELD, "myField"), -1, -2);
+        assertValues(find(annotations, Kind.FIELD, "anotherField"), -3);
     }
 
     @Test
     public void testClassInfo() throws IOException {
         Index index = getIndexForClass(MY_ANNOTATED_NAME, ALPHA_NAME);
         ClassInfo alpha = index.getClassByName(MY_ANNOTATED_NAME);
-        assertValues(alpha.declaredAnnotationsWithRepeatable(ALPHA_NAME, index), 0);
+        assertClassInfo(alpha.declaredAnnotationsWithRepeatable(ALPHA_NAME, index));
+        assertClassInfo(alpha.declaredAnnotationsWithRepeatable(ALPHA_NAME, ALPHA_CONTAINER_NAME));
+    }
+
+    private void assertClassInfo(Collection<AnnotationInstance> annotations) {
+        assertValues(annotations, 0);
     }
 
     @Test
@@ -74,22 +81,28 @@ public class RepeatableAnnotationsTestCase {
         Index index = getIndexForClass(MY_ANNOTATED_NAME, ALPHA_NAME);
         ClassInfo alpha = index.getClassByName(MY_ANNOTATED_NAME);
         // MyAnnotated.foo()
-        MethodInfo foo = alpha.method("foo",
-                Type.create(DotName.createSimple(String.class.getName()), org.jboss.jandex.Type.Kind.CLASS));
-        List<AnnotationInstance> fooInstances = foo.annotationsWithRepeatable(ALPHA_NAME, index);
-        assertEquals(3, fooInstances.size());
-        assertValues(find(fooInstances, Kind.METHOD, null), 1);
-        assertValues(find(fooInstances, Kind.METHOD_PARAMETER, null), 11, 12);
+        MethodInfo foo = alpha.firstMethod("foo");
+        assertMethodInfoFoo(foo.annotationsWithRepeatable(ALPHA_NAME, index));
+        assertMethodInfoFoo(foo.annotationsWithRepeatable(ALPHA_NAME, ALPHA_CONTAINER_NAME));
         // MyAnnotated.bar()
-        MethodInfo bar = alpha.method("bar",
-                Type.create(DotName.createSimple(String.class.getName()), org.jboss.jandex.Type.Kind.CLASS));
-        List<AnnotationInstance> barInstances = bar.annotationsWithRepeatable(ALPHA_NAME, index);
-        assertEquals(3, barInstances.size());
-        List<AnnotationInstance> barMethodInstance = find(barInstances, Kind.METHOD, null);
+        MethodInfo bar = alpha.firstMethod("bar");
+        assertMethodInfoBar(bar.annotationsWithRepeatable(ALPHA_NAME, index), bar);
+        assertMethodInfoBar(bar.annotationsWithRepeatable(ALPHA_NAME, ALPHA_CONTAINER_NAME), bar);
+    }
+
+    private void assertMethodInfoFoo(Collection<AnnotationInstance> annotations) {
+        assertEquals(3, annotations.size());
+        assertValues(find(annotations, Kind.METHOD, null), 1);
+        assertValues(find(annotations, Kind.METHOD_PARAMETER, null), 11, 12);
+    }
+
+    private void assertMethodInfoBar(Collection<AnnotationInstance> annotations, MethodInfo bar) {
+        assertEquals(3, annotations.size());
+        List<AnnotationInstance> barMethodInstance = find(annotations, Kind.METHOD, null);
         // Test the target of an instance coming from the container
         assertEquals(bar, barMethodInstance.get(0).target());
         assertValues(barMethodInstance, 2, 3);
-        assertValues(find(barInstances, Kind.METHOD_PARAMETER, null), 10);
+        assertValues(find(annotations, Kind.METHOD_PARAMETER, null), 10);
     }
 
     @Test
@@ -97,13 +110,23 @@ public class RepeatableAnnotationsTestCase {
         Index index = getIndexForClass(MY_ANNOTATED_NAME, ALPHA_NAME);
         ClassInfo alpha = index.getClassByName(MY_ANNOTATED_NAME);
         FieldInfo myField = alpha.field("myField");
-        assertValues(myField.annotationsWithRepeatable(ALPHA_NAME, index), -1, -2);
+        assertFieldInfoMyField(myField.annotationsWithRepeatable(ALPHA_NAME, index));
+        assertFieldInfoMyField(myField.annotationsWithRepeatable(ALPHA_NAME, ALPHA_CONTAINER_NAME));
         FieldInfo anotherField = alpha.field("anotherField");
-        assertValues(anotherField.annotationsWithRepeatable(ALPHA_NAME, index), -3);
-        // Test that it's still possible to query the contaier annotation
+        assertFieldInfoAnotherField(anotherField.annotationsWithRepeatable(ALPHA_NAME, index));
+        assertFieldInfoAnotherField(anotherField.annotationsWithRepeatable(ALPHA_NAME, ALPHA_CONTAINER_NAME));
+        // Test that it's still possible to query the container annotation
         List<AnnotationInstance> direct = myField.annotations();
         assertEquals(1, direct.size());
         assertEquals(ALPHA_CONTAINER_NAME, direct.get(0).name());
+    }
+
+    private void assertFieldInfoMyField(Collection<AnnotationInstance> annotations) {
+        assertValues(annotations, -1, -2);
+    }
+
+    private void assertFieldInfoAnotherField(Collection<AnnotationInstance> annotations) {
+        assertValues(annotations, -3);
     }
 
     @Test

--- a/core/src/test/java/org/jboss/jandex/test/StackedIndexTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/StackedIndexTest.java
@@ -130,6 +130,12 @@ public class StackedIndexTest {
         for (AnnotationInstance annotation : annotations) {
             assertFalse(annotation.value().asString().startsWith("XXX"));
         }
+
+        annotations = index.getAnnotationsWithRepeatable(MyRepeatableAnnotation.DOT_NAME, MyRepeatableAnnotation.List.DOT_NAME);
+        assertEquals(11, annotations.size());
+        for (AnnotationInstance annotation : annotations) {
+            assertFalse(annotation.value().asString().startsWith("XXX"));
+        }
     }
 
     private static byte[] annotatedClass3AsAnnotatedClass1() throws IOException {


### PR DESCRIPTION
The following methods:

- `IndexView.getAnnotationsWithRepeatable()`
- `AnnotationTarget.annotationsWithRepeatable()`
- `AnnotationTarget.declaredAnnotationsWithRepeatable()`
- `Type.annotationsWithRepeatable()`

require an annotation name on the input, together with an index that is used to obtain the annotation class. If the annotation is repeatable, these methods also return all values of the container annotation.

Very often, when these methods are called, the user _knows_ that the annotation is repeatable and has access to the name of the container annotation. For these cases, this commit adds overloads that accept an annotation name and a container annotation name, instead of an index. If the second annotation name does not name a container annotation for repeatable occurences of the first annotation name, the behavior of these overloads is undefined.

Fixes #663