### PR TITLE
Deduplicate CompositeIndex results by class name (#174)

### DIFF
--- a/core/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/core/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -26,7 +26,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
@@ -104,14 +107,16 @@ public class CompositeIndex implements IndexView {
      */
     @Override
     public Set<ClassInfo> getKnownDirectSubclasses(final DotName className) {
-        final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
+        final Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         for (IndexView index : indexes) {
             final Collection<ClassInfo> list = index.getKnownDirectSubclasses(className);
             if (list != null) {
-                allKnown.addAll(list);
+                for (ClassInfo clazz : list) {
+                    allKnown.putIfAbsent(clazz.name(), clazz);
+                }
             }
         }
-        return Collections.unmodifiableSet(allKnown);
+        return Collections.unmodifiableSet(new LinkedHashSet<ClassInfo>(allKnown.values()));
     }
 
     /**
@@ -119,13 +124,13 @@ public class CompositeIndex implements IndexView {
      */
     @Override
     public Set<ClassInfo> getAllKnownSubclasses(final DotName className) {
-        final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
+        final Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         final Set<DotName> processedClasses = new HashSet<DotName>();
         getAllKnownSubClasses(className, allKnown, processedClasses);
-        return allKnown;
+        return Collections.unmodifiableSet(new LinkedHashSet<ClassInfo>(allKnown.values()));
     }
 
-    private void getAllKnownSubClasses(DotName className, Set<ClassInfo> allKnown, Set<DotName> processedClasses) {
+    private void getAllKnownSubClasses(DotName className, Map<DotName, ClassInfo> allKnown, Set<DotName> processedClasses) {
         final Set<DotName> subClassesToProcess = new HashSet<DotName>();
         subClassesToProcess.add(className);
         while (!subClassesToProcess.isEmpty()) {
@@ -137,7 +142,7 @@ public class CompositeIndex implements IndexView {
         }
     }
 
-    private void getAllKnownSubClasses(DotName name, Set<ClassInfo> allKnown, Set<DotName> subClassesToProcess,
+    private void getAllKnownSubClasses(DotName name, Map<DotName, ClassInfo> allKnown, Set<DotName> subClassesToProcess,
             Set<DotName> processedClasses) {
         for (IndexView index : indexes) {
             final Collection<ClassInfo> list = index.getKnownDirectSubclasses(name);
@@ -145,7 +150,7 @@ public class CompositeIndex implements IndexView {
                 for (final ClassInfo clazz : list) {
                     final DotName className = clazz.name();
                     if (!processedClasses.contains(className)) {
-                        allKnown.add(clazz);
+                        allKnown.putIfAbsent(className, clazz);
                         subClassesToProcess.add(className);
                     }
                 }
@@ -158,14 +163,16 @@ public class CompositeIndex implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getKnownDirectSubinterfaces(DotName interfaceName) {
-        Set<ClassInfo> allKnown = new HashSet<>();
+        Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         for (IndexView index : indexes) {
             Collection<ClassInfo> list = index.getKnownDirectSubinterfaces(interfaceName);
             if (list != null) {
-                allKnown.addAll(list);
+                for (ClassInfo clazz : list) {
+                    allKnown.putIfAbsent(clazz.name(), clazz);
+                }
             }
         }
-        return Collections.unmodifiableSet(allKnown);
+        return Collections.unmodifiableCollection(allKnown.values());
     }
 
     /**
@@ -173,7 +180,7 @@ public class CompositeIndex implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName) {
-        Set<ClassInfo> result = new HashSet<>();
+        Map<DotName, ClassInfo> result = new LinkedHashMap<DotName, ClassInfo>();
 
         Queue<DotName> worklist = new ArrayDeque<>();
         Set<DotName> alreadyProcessed = new HashSet<>();
@@ -187,25 +194,27 @@ public class CompositeIndex implements IndexView {
 
             for (IndexView index : indexes) {
                 for (ClassInfo directSubinterface : index.getKnownDirectSubinterfaces(iface)) {
-                    result.add(directSubinterface);
+                    result.putIfAbsent(directSubinterface.name(), directSubinterface);
                     worklist.add(directSubinterface.name());
                 }
             }
         }
 
-        return result;
+        return Collections.unmodifiableCollection(result.values());
     }
 
     @Override
     public Collection<ClassInfo> getKnownDirectImplementations(DotName interfaceName) {
-        Set<ClassInfo> allKnown = new HashSet<>();
+        Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         for (IndexView index : indexes) {
             Collection<ClassInfo> list = index.getKnownDirectImplementations(interfaceName);
             if (list != null) {
-                allKnown.addAll(list);
+                for (ClassInfo clazz : list) {
+                    allKnown.putIfAbsent(clazz.name(), clazz);
+                }
             }
         }
-        return Collections.unmodifiableSet(allKnown);
+        return Collections.unmodifiableCollection(allKnown.values());
     }
 
     @Override
@@ -219,14 +228,16 @@ public class CompositeIndex implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getKnownDirectImplementors(final DotName interfaceName) {
-        final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
+        final Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         for (IndexView index : indexes) {
             final Collection<ClassInfo> list = index.getKnownDirectImplementors(interfaceName);
             if (list != null) {
-                allKnown.addAll(list);
+                for (ClassInfo clazz : list) {
+                    allKnown.putIfAbsent(clazz.name(), clazz);
+                }
             }
         }
-        return Collections.unmodifiableSet(allKnown);
+        return Collections.unmodifiableCollection(allKnown.values());
     }
 
     /**
@@ -234,7 +245,7 @@ public class CompositeIndex implements IndexView {
      */
     @Override
     public Set<ClassInfo> getAllKnownImplementors(final DotName interfaceName) {
-        final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
+        final Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         final Set<DotName> subInterfacesToProcess = new HashSet<DotName>();
         final Set<DotName> processedClasses = new HashSet<DotName>();
         subInterfacesToProcess.add(interfaceName);
@@ -245,10 +256,10 @@ public class CompositeIndex implements IndexView {
             processedClasses.add(name);
             getKnownImplementors(name, allKnown, subInterfacesToProcess, processedClasses);
         }
-        return allKnown;
+        return Collections.unmodifiableSet(new LinkedHashSet<ClassInfo>(allKnown.values()));
     }
 
-    private void getKnownImplementors(DotName name, Set<ClassInfo> allKnown, Set<DotName> subInterfacesToProcess,
+    private void getKnownImplementors(DotName name, Map<DotName, ClassInfo> allKnown, Set<DotName> subInterfacesToProcess,
             Set<DotName> processedClasses) {
         for (IndexView index : indexes) {
             final Collection<ClassInfo> list = index.getKnownDirectImplementors(name);
@@ -259,8 +270,8 @@ public class CompositeIndex implements IndexView {
                         if (Modifier.isInterface(clazz.flags())) {
                             subInterfacesToProcess.add(className);
                         } else {
-                            if (!allKnown.contains(clazz)) {
-                                allKnown.add(clazz);
+                            if (!allKnown.containsKey(className)) {
+                                allKnown.put(className, clazz);
                                 processedClasses.add(className);
                                 getAllKnownSubClasses(className, allKnown, processedClasses);
                             }

--- a/core/src/main/java/org/jboss/jandex/Index.java
+++ b/core/src/main/java/org/jboss/jandex/Index.java
@@ -36,6 +36,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -382,13 +384,13 @@ public final class Index implements IndexView {
 
     @Override
     public Collection<ClassInfo> getAllKnownSubclasses(DotName className) {
-        final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
+        final Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         final Set<DotName> processedClasses = new HashSet<DotName>();
         getAllKnownSubClasses(className, allKnown, processedClasses);
-        return allKnown;
+        return Collections.unmodifiableCollection(allKnown.values());
     }
 
-    private void getAllKnownSubClasses(DotName className, Set<ClassInfo> allKnown, Set<DotName> processedClasses) {
+    private void getAllKnownSubClasses(DotName className, Map<DotName, ClassInfo> allKnown, Set<DotName> processedClasses) {
         final Set<DotName> subClassesToProcess = new HashSet<DotName>();
         subClassesToProcess.add(className);
         while (!subClassesToProcess.isEmpty()) {
@@ -400,14 +402,14 @@ public final class Index implements IndexView {
         }
     }
 
-    private void getAllKnownSubClasses(DotName name, Set<ClassInfo> allKnown, Set<DotName> subClassesToProcess,
+    private void getAllKnownSubClasses(DotName name, Map<DotName, ClassInfo> allKnown, Set<DotName> subClassesToProcess,
             Set<DotName> processedClasses) {
         final List<ClassInfo> list = getKnownDirectSubclasses(name);
         if (list != null) {
             for (final ClassInfo clazz : list) {
                 final DotName className = clazz.name();
                 if (!processedClasses.contains(className)) {
-                    allKnown.add(clazz);
+                    allKnown.put(className, clazz);
                     subClassesToProcess.add(className);
                 }
             }
@@ -428,7 +430,7 @@ public final class Index implements IndexView {
      */
     @Override
     public Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName) {
-        Set<ClassInfo> result = new HashSet<>();
+        Map<DotName, ClassInfo> result = new LinkedHashMap<DotName, ClassInfo>();
 
         Queue<DotName> worklist = new ArrayDeque<>();
         Set<DotName> alreadyProcessed = new HashSet<>();
@@ -441,12 +443,12 @@ public final class Index implements IndexView {
             }
 
             for (ClassInfo directSubinterface : getKnownDirectSubinterfaces(iface)) {
-                result.add(directSubinterface);
+                result.put(directSubinterface.name(), directSubinterface);
                 worklist.add(directSubinterface.name());
             }
         }
 
-        return result;
+        return Collections.unmodifiableCollection(result.values());
     }
 
     @Override
@@ -494,7 +496,7 @@ public final class Index implements IndexView {
      */
     @Override
     public Set<ClassInfo> getAllKnownImplementors(final DotName interfaceName) {
-        final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
+        final Map<DotName, ClassInfo> allKnown = new LinkedHashMap<DotName, ClassInfo>();
         final Set<DotName> subInterfacesToProcess = new HashSet<DotName>();
         final Set<DotName> processedClasses = new HashSet<DotName>();
         subInterfacesToProcess.add(interfaceName);
@@ -505,10 +507,10 @@ public final class Index implements IndexView {
             processedClasses.add(name);
             getKnownImplementors(name, allKnown, subInterfacesToProcess, processedClasses);
         }
-        return allKnown;
+        return Collections.unmodifiableSet(new LinkedHashSet<ClassInfo>(allKnown.values()));
     }
 
-    private void getKnownImplementors(DotName name, Set<ClassInfo> allKnown, Set<DotName> subInterfacesToProcess,
+    private void getKnownImplementors(DotName name, Map<DotName, ClassInfo> allKnown, Set<DotName> subInterfacesToProcess,
             Set<DotName> processedClasses) {
         final List<ClassInfo> list = getKnownDirectImplementors(name);
         if (list != null) {
@@ -518,8 +520,8 @@ public final class Index implements IndexView {
                     if (Modifier.isInterface(clazz.flags())) {
                         subInterfacesToProcess.add(className);
                     } else {
-                        if (!allKnown.contains(clazz)) {
-                            allKnown.add(clazz);
+                        if (!allKnown.containsKey(className)) {
+                            allKnown.put(className, clazz);
                             processedClasses.add(className);
                             getAllKnownSubClasses(className, allKnown, processedClasses);
                         }

--- a/core/src/test/java/org/jboss/jandex/test/CompositeTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/CompositeTestCase.java
@@ -19,12 +19,15 @@
 package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -41,6 +44,10 @@ public class CompositeTestCase {
             Collections.<DotName, List<AnnotationInstance>> emptyMap(), false);
     private static final DotName BAR_NAME = DotName.createSimple("foo.Bar");
     private static final DotName FOO_NAME = DotName.createSimple("foo.Foo");
+
+    private static final DotName DUP_IFACE = DotName.createSimple("foo.Iface");
+    private static final DotName DUP_SUB = DotName.createSimple("foo.Sub");
+    private static final DotName DUP_IMPL = DotName.createSimple("foo.Impl");
 
     @Test
     public void testComposite() {
@@ -95,5 +102,54 @@ public class CompositeTestCase {
         subclasses.put(BASE_NAME, Collections.singletonList(classInfo));
 
         return Index.create(annotations, subclasses, implementors, classes);
+    }
+
+    // Regression test for issue #174: a CompositeIndex must deduplicate results by class name.
+    // ClassInfo has no equals/hashCode, so the previous HashSet<ClassInfo> accumulators deduped by
+    // identity and let the same FQCN appear multiple times when merged across indexes. Here each
+    // index contributes a DISTINCT ClassInfo instance for the same FQCN, so identity dedup would
+    // have kept both.
+    @Test
+    public void testCompositeDeduplicatesByClassName() {
+        CompositeIndex index = CompositeIndex.create(createDuplicatingIndex(), createDuplicatingIndex());
+
+        assertEquals(1, index.getKnownDirectSubclasses(DotName.OBJECT_NAME).size());
+        assertEquals(1, index.getAllKnownSubclasses(DotName.OBJECT_NAME).size());
+        assertEquals(1, index.getKnownDirectImplementors(DUP_IFACE).size());
+        assertEquals(1, index.getAllKnownImplementors(DUP_IFACE).size());
+        assertEquals(1, index.getKnownDirectImplementations(DUP_IFACE).size());
+        assertEquals(1, index.getAllKnownImplementations(DUP_IFACE).size());
+
+        assertUniqueNames(index.getKnownDirectSubclasses(DotName.OBJECT_NAME));
+        assertUniqueNames(index.getAllKnownSubclasses(DotName.OBJECT_NAME));
+        assertUniqueNames(index.getKnownDirectImplementors(DUP_IFACE));
+        assertUniqueNames(index.getAllKnownImplementors(DUP_IFACE));
+    }
+
+    private void assertUniqueNames(Collection<ClassInfo> classes) {
+        Set<DotName> names = new HashSet<DotName>();
+        for (ClassInfo clazz : classes) {
+            assertTrue(names.add(clazz.name()), "duplicate class name in result: " + clazz.name());
+        }
+    }
+
+    // Each invocation produces fresh ClassInfo instances for the same FQCNs.
+    private Index createDuplicatingIndex() {
+        ClassInfo sub = ClassInfo.create(DUP_SUB, DotName.OBJECT_NAME, (short) 0, new DotName[0],
+                Collections.<DotName, List<AnnotationInstance>> emptyMap(), false);
+        ClassInfo impl = ClassInfo.create(DUP_IMPL, DotName.OBJECT_NAME, (short) 0, new DotName[] { DUP_IFACE },
+                Collections.<DotName, List<AnnotationInstance>> emptyMap(), false);
+
+        Map<DotName, List<ClassInfo>> subclasses = new HashMap<DotName, List<ClassInfo>>();
+        subclasses.put(DotName.OBJECT_NAME, Collections.singletonList(sub));
+
+        Map<DotName, List<ClassInfo>> implementors = new HashMap<DotName, List<ClassInfo>>();
+        implementors.put(DUP_IFACE, Collections.singletonList(impl));
+
+        Map<DotName, ClassInfo> classes = new HashMap<DotName, ClassInfo>();
+        classes.put(DUP_SUB, sub);
+        classes.put(DUP_IMPL, impl);
+
+        return Index.create(Collections.<DotName, List<AnnotationInstance>> emptyMap(), subclasses, implementors, classes);
     }
 }

--- a/core/src/test/java/org/jboss/jandex/test/IndexNavigationTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/IndexNavigationTest.java
@@ -108,66 +108,63 @@ public class IndexNavigationTest {
     }
 
     private void doTestOverlappingCompositeIndex(IndexView index) {
+        // issue #174: an overlapping CompositeIndex now deduplicates results by class name, so
+        // classes present in more than one index appear only once (previously they appeared once per index).
         assertCollection(index.getKnownDirectSubclasses(Object.class), IGrandparent.class, IParent.class, IChild.class,
-                IGrandchild1.class, CGrandparent.class, IChild.class, ISibling.class, IGrandchild1.class, IGrandchild2.class);
-        assertCollection(index.getKnownDirectSubclasses(CParent.class), CChild.class, CChild.class, CSibling.class);
-        assertCollection(index.getKnownDirectSubclasses(CChild.class), CGrandchild1.class, CGrandchild1.class,
-                CGrandchild2.class);
+                IGrandchild1.class, CGrandparent.class, ISibling.class, IGrandchild2.class);
+        assertCollection(index.getKnownDirectSubclasses(CParent.class), CChild.class, CSibling.class);
+        assertCollection(index.getKnownDirectSubclasses(CChild.class), CGrandchild1.class, CGrandchild2.class);
 
         assertCollection(index.getAllKnownSubclasses(Object.class), IGrandparent.class, IParent.class, IChild.class,
-                IGrandchild1.class, CGrandparent.class, CParent.class, CChild.class, CGrandchild1.class, IChild.class,
-                ISibling.class, IGrandchild1.class, IGrandchild2.class, CChild.class, CSibling.class, CGrandchild1.class,
-                CGrandchild2.class);
+                IGrandchild1.class, CGrandparent.class, CParent.class, CChild.class, CGrandchild1.class,
+                ISibling.class, IGrandchild2.class, CSibling.class, CGrandchild2.class);
         assertCollection(index.getAllKnownSubclasses(CGrandparent.class), CParent.class, CChild.class, CGrandchild1.class,
-                CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
-        assertCollection(index.getAllKnownSubclasses(CParent.class), CChild.class, CGrandchild1.class, CChild.class,
-                CSibling.class, CGrandchild1.class, CGrandchild2.class);
-        assertCollection(index.getAllKnownSubclasses(CChild.class), CGrandchild1.class, CGrandchild1.class, CGrandchild2.class);
+                CSibling.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownSubclasses(CParent.class), CChild.class, CGrandchild1.class,
+                CSibling.class, CGrandchild2.class);
+        assertCollection(index.getAllKnownSubclasses(CChild.class), CGrandchild1.class, CGrandchild2.class);
 
         assertCollection(index.getKnownDirectSubinterfaces(IGrandparent.class), IParent.class);
-        assertCollection(index.getKnownDirectSubinterfaces(IParent.class), IChild.class, IChild.class, ISibling.class);
-        assertCollection(index.getKnownDirectSubinterfaces(IChild.class), IGrandchild1.class, IGrandchild1.class,
-                IGrandchild2.class);
+        assertCollection(index.getKnownDirectSubinterfaces(IParent.class), IChild.class, ISibling.class);
+        assertCollection(index.getKnownDirectSubinterfaces(IChild.class), IGrandchild1.class, IGrandchild2.class);
 
         assertCollection(index.getAllKnownSubinterfaces(IGrandparent.class), IParent.class, IChild.class, IGrandchild1.class,
-                IChild.class, ISibling.class, IGrandchild1.class, IGrandchild2.class);
-        assertCollection(index.getAllKnownSubinterfaces(IParent.class), IChild.class, IGrandchild1.class, IChild.class,
-                ISibling.class, IGrandchild1.class, IGrandchild2.class);
-        assertCollection(index.getAllKnownSubinterfaces(IChild.class), IGrandchild1.class, IGrandchild1.class,
-                IGrandchild2.class);
+                ISibling.class, IGrandchild2.class);
+        assertCollection(index.getAllKnownSubinterfaces(IParent.class), IChild.class, IGrandchild1.class,
+                ISibling.class, IGrandchild2.class);
+        assertCollection(index.getAllKnownSubinterfaces(IChild.class), IGrandchild1.class, IGrandchild2.class);
 
         assertCollection(index.getKnownDirectImplementations(IGrandparent.class), CGrandparent.class);
         assertCollection(index.getKnownDirectImplementations(IParent.class), CParent.class);
-        assertCollection(index.getKnownDirectImplementations(IChild.class), CChild.class, CChild.class);
+        assertCollection(index.getKnownDirectImplementations(IChild.class), CChild.class);
         assertCollection(index.getKnownDirectImplementations(ISibling.class), CSibling.class);
-        assertCollection(index.getKnownDirectImplementations(IGrandchild1.class), CGrandchild1.class, CGrandchild1.class);
+        assertCollection(index.getKnownDirectImplementations(IGrandchild1.class), CGrandchild1.class);
         assertCollection(index.getKnownDirectImplementations(IGrandchild2.class), CGrandchild2.class);
 
         assertCollection(index.getAllKnownImplementations(IGrandparent.class), CGrandparent.class, CParent.class, CChild.class,
-                CGrandchild1.class, CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
+                CGrandchild1.class, CSibling.class, CGrandchild2.class);
         assertCollection(index.getAllKnownImplementations(IParent.class), CParent.class, CChild.class, CGrandchild1.class,
-                CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
+                CSibling.class, CGrandchild2.class);
         // doesn't behave as expected, but the behavior is actually not defined
-        //assertCollection(index.getAllKnownImplementations(IChild.class), CChild.class, CGrandchild1.class, CChild.class, CGrandchild1.class, CGrandchild2.class);
+        //assertCollection(index.getAllKnownImplementations(IChild.class), CChild.class, CGrandchild1.class, CGrandchild2.class);
         assertCollection(index.getAllKnownImplementations(ISibling.class), CSibling.class);
         assertCollection(index.getAllKnownImplementations(IGrandchild1.class), CGrandchild1.class);
         assertCollection(index.getAllKnownImplementations(IGrandchild2.class), CGrandchild2.class);
 
         assertCollection(index.getKnownDirectImplementors(IGrandparent.class), CGrandparent.class, IParent.class);
-        assertCollection(index.getKnownDirectImplementors(IParent.class), IChild.class, CParent.class, IChild.class,
-                ISibling.class);
-        assertCollection(index.getKnownDirectImplementors(IChild.class), IGrandchild1.class, CChild.class, IGrandchild1.class,
-                IGrandchild2.class, CChild.class);
+        assertCollection(index.getKnownDirectImplementors(IParent.class), IChild.class, CParent.class, ISibling.class);
+        assertCollection(index.getKnownDirectImplementors(IChild.class), IGrandchild1.class, CChild.class,
+                IGrandchild2.class);
         assertCollection(index.getKnownDirectImplementors(ISibling.class), CSibling.class);
-        assertCollection(index.getKnownDirectImplementors(IGrandchild1.class), CGrandchild1.class, CGrandchild1.class);
+        assertCollection(index.getKnownDirectImplementors(IGrandchild1.class), CGrandchild1.class);
         assertCollection(index.getKnownDirectImplementors(IGrandchild2.class), CGrandchild2.class);
 
         assertCollection(index.getAllKnownImplementors(IGrandparent.class), CGrandparent.class, CParent.class, CChild.class,
-                CGrandchild1.class, CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
+                CGrandchild1.class, CSibling.class, CGrandchild2.class);
         assertCollection(index.getAllKnownImplementors(IParent.class), CParent.class, CChild.class, CGrandchild1.class,
-                CChild.class, CSibling.class, CGrandchild1.class, CGrandchild2.class);
+                CSibling.class, CGrandchild2.class);
         // doesn't behave as expected, but the behavior is actually not defined
-        //assertCollection(index.getAllKnownImplementors(IChild.class), CChild.class, CGrandchild1.class, CChild.class, CGrandchild1.class, CGrandchild2.class);
+        //assertCollection(index.getAllKnownImplementors(IChild.class), CChild.class, CGrandchild1.class, CGrandchild2.class);
         assertCollection(index.getAllKnownImplementors(ISibling.class), CSibling.class);
         assertCollection(index.getAllKnownImplementors(IGrandchild1.class), CGrandchild1.class);
         assertCollection(index.getAllKnownImplementors(IGrandchild2.class), CGrandchild2.class);


### PR DESCRIPTION
Fixes #174.

## Problem

`ClassInfo` defines no `equals`/`hashCode`, so the `HashSet<ClassInfo>` accumulators in `Index` and `CompositeIndex` deduplicate by object identity. In an **overlapping `CompositeIndex`** (the same class indexed in more than one member index) this let the same fully-qualified class name appear **once per index** in the results of:

- `getKnownDirectSubclasses` / `getAllKnownSubclasses`
- `getKnownDirectSubinterfaces` / `getAllKnownSubinterfaces`
- `getKnownDirectImplementations`
- `getKnownDirectImplementors` / `getAllKnownImplementors`

This was inconsistent with `getKnownUsers`, `getClassesInPackage`, and `getAllKnownSubinterfaces`' worklist, which already deduplicate by `clazz.name()`.

## Change

Replaced the internal `Set<ClassInfo>` accumulators/parameters/locals in `Index` and `CompositeIndex` with name-keyed `Map<DotName, ClassInfo>` (`LinkedHashMap` for deterministic order; `putIfAbsent`/`containsKey` = first-writer-wins, matching `getClassByName`, which returns the first index's match). The traversal/visited-tracking logic (`processedClasses`, worklists) is unchanged.

- **Public API is preserved.** Declared return types are identical — the methods declared `Set<ClassInfo>` still return a `Set` (materialized from the deduplicated map values at the boundary); `Collection<ClassInfo>` returners still return a `Collection`. No `IndexView` signature, no `equals`/`hashCode` on `ClassInfo`, no on-disk index-format change. `Indexer` is untouched.
- Base source set stays Java 8 compatible.

## Behavior changes (please review)

1. **Deduplication by name** for the methods above on an overlapping `CompositeIndex`. This is the substance of #174. Since @Ladicek noted he wasn't fully convinced the identity semantics were safe to drop, I've kept this deliberate and easy to review: `IndexNavigationTest.testOverlappingCompositeIndex` previously asserted the duplicate-preserving behavior and is updated here to assert the deduplicated results. Happy to adjust the direction based on your preference.
2. A few `getAll*` methods that previously returned a mutable set now return an **unmodifiable** collection, consistent with the sibling `getKnownDirect*` methods that already did.

## Tests

- Added `CompositeTestCase.testCompositeDeduplicatesByClassName`: two indexes each contributing a *distinct* `ClassInfo` instance for the same FQCN; asserts the composite returns exactly one entry per name across the affected accessors.
- Updated `IndexNavigationTest.testOverlappingCompositeIndex` to expect deduplicated-by-name results.
- Full `core` build is green (302 tests) on JDK 21, formatter + impsort clean.