### PR TITLE
Return unmodifiable collections from getAllKnown* methods

### DIFF
--- a/core/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/core/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -122,7 +122,7 @@ public class CompositeIndex implements IndexView {
         final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
         final Set<DotName> processedClasses = new HashSet<DotName>();
         getAllKnownSubClasses(className, allKnown, processedClasses);
-        return allKnown;
+        return Collections.unmodifiableSet(allKnown);
     }
 
     private void getAllKnownSubClasses(DotName className, Set<ClassInfo> allKnown, Set<DotName> processedClasses) {
@@ -193,7 +193,7 @@ public class CompositeIndex implements IndexView {
             }
         }
 
-        return result;
+        return Collections.unmodifiableSet(result);
     }
 
     @Override
@@ -245,7 +245,7 @@ public class CompositeIndex implements IndexView {
             processedClasses.add(name);
             getKnownImplementors(name, allKnown, subInterfacesToProcess, processedClasses);
         }
-        return allKnown;
+        return Collections.unmodifiableSet(allKnown);
     }
 
     private void getKnownImplementors(DotName name, Set<ClassInfo> allKnown, Set<DotName> subInterfacesToProcess,

--- a/core/src/main/java/org/jboss/jandex/Index.java
+++ b/core/src/main/java/org/jboss/jandex/Index.java
@@ -385,7 +385,7 @@ public final class Index implements IndexView {
         final Set<ClassInfo> allKnown = new HashSet<ClassInfo>();
         final Set<DotName> processedClasses = new HashSet<DotName>();
         getAllKnownSubClasses(className, allKnown, processedClasses);
-        return allKnown;
+        return Collections.unmodifiableSet(allKnown);
     }
 
     private void getAllKnownSubClasses(DotName className, Set<ClassInfo> allKnown, Set<DotName> processedClasses) {
@@ -446,7 +446,7 @@ public final class Index implements IndexView {
             }
         }
 
-        return result;
+        return Collections.unmodifiableSet(result);
     }
 
     @Override
@@ -505,7 +505,7 @@ public final class Index implements IndexView {
             processedClasses.add(name);
             getKnownImplementors(name, allKnown, subInterfacesToProcess, processedClasses);
         }
-        return allKnown;
+        return Collections.unmodifiableSet(allKnown);
     }
 
     private void getKnownImplementors(DotName name, Set<ClassInfo> allKnown, Set<DotName> subInterfacesToProcess,

--- a/core/src/test/java/org/jboss/jandex/test/IndexNavigationTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/IndexNavigationTest.java
@@ -1,6 +1,7 @@
 package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -203,6 +204,32 @@ public class IndexNavigationTest {
 
         index = StackedIndex.create(IndexingUtil.roundtrip(index1), IndexingUtil.roundtrip(index2));
         testIndex(index);
+    }
+
+    @Test
+    public void testAllKnownCollectionsAreUnmodifiable() throws IOException {
+        Index index = Index.of(IGrandparent.class, IParent.class, IChild.class, ISibling.class, IGrandchild1.class,
+                IGrandchild2.class, CGrandparent.class, CParent.class, CChild.class, CSibling.class, CGrandchild1.class,
+                CGrandchild2.class);
+        testUnmodifiable(index);
+        testUnmodifiable(CompositeIndex.create(index));
+
+        index = IndexingUtil.roundtrip(index);
+        testUnmodifiable(index);
+        testUnmodifiable(CompositeIndex.create(index));
+        testUnmodifiable(StackedIndex.create(index));
+    }
+
+    private void testUnmodifiable(IndexView index) {
+        assertUnmodifiable(index.getAllKnownSubclasses(CGrandparent.class));
+        assertUnmodifiable(index.getAllKnownSubinterfaces(IGrandparent.class));
+        assertUnmodifiable(index.getAllKnownImplementations(IGrandparent.class));
+        assertUnmodifiable(index.getAllKnownImplementors(IGrandparent.class));
+    }
+
+    private static void assertUnmodifiable(Collection<ClassInfo> collection) {
+        assertTrue(collection.size() > 0, "Expected a non-empty collection to test");
+        assertThrows(UnsupportedOperationException.class, collection::clear);
     }
 
     private void testIndex(IndexView index) {


### PR DESCRIPTION
`Index` and `CompositeIndex` returned their internal `HashSet` accumulators directly from `getAllKnownSubclasses`, `getAllKnownSubinterfaces`, and `getAllKnownImplementors` (and, by delegation, `getAllKnownImplementations`). That let callers mutate the returned set, which was never intended and is inconsistent with the sibling methods such as `getKnownDirectSubclasses` that already wrap their results with `Collections.unmodifiableSet`.

This wraps the returned sets so all of these methods hand back an unmodifiable view. Contents and iteration order are unchanged; the only new behavior is that mutating the result now fails with `UnsupportedOperationException`.

This is the part of #707 you said was acceptable, split out on its own without the name-based deduplication from that PR.

Verified with `mvn -pl core test` (317 tests, all passing), including a new `IndexNavigationTest.testAllKnownCollectionsAreUnmodifiable` that checks both `Index` and `CompositeIndex`, before and after a serialization roundtrip.

One thing worth calling out: this is a behavioral tightening, so any existing code that mutates a returned set would now break with `UnsupportedOperationException`.
